### PR TITLE
Update decorators.py

### DIFF
--- a/sanic_jwt/decorators.py
+++ b/sanic_jwt/decorators.py
@@ -7,6 +7,10 @@ def protected():
     def decorator(f):
         @wraps(f)
         async def decorated_function(request, *args, **kwargs):
+            if request.method == 'OPTIONS':
+                response = await f(request, *args, **kwargs)
+                return response
+
             is_authorized = request.app.auth.is_authenticated(request, *args, **kwargs)
 
             if is_authorized:


### PR DESCRIPTION
As preflight request(CORS) explicitly exclude authenticate headers on OPTIONS request, we should avoid authenticate OPTIONS request.

If you find other method to handle protected decorateror with CORS let me know...

https://www.w3.org/TR/cors/#cross-origin-request-with-preflight-0
"""
Exclude user credentials.
"""