### PR TITLE
Documentation inconsistent with example code & API

### DIFF
--- a/docs/source/pages/simpleusage.rst
+++ b/docs/source/pages/simpleusage.rst
@@ -12,14 +12,15 @@ Let's take a look at a real simple example on how to use Sanic JWT to see the co
             self.username = username
             self.password = password
 
-        def __str__(self):
-            return "User(id={})".format(self.id)
+        def __repr__(self):
+            return "User(id='{}')".format(self.user_id)
 
         def to_dict(self):
             return {
                 'user_id': self.user_id,
                 'username': self.username,
             }
+
 
     users = [
         User(1, 'user1', 'abcxyz'),
@@ -72,8 +73,14 @@ Our whole application now looks like this:
             self.username = username
             self.password = password
 
-        def __str__(self):
-            return "User(id='%s')" % self.id
+        def __repr__(self):
+            return "User(id='{}')".format(self.user_id)
+
+        def to_dict(self):
+            return {
+                'user_id': self.user_id,
+                'username': self.username,
+            }
 
 
     users = [


### PR DESCRIPTION
The code displayed in the documentation is inconsistent with the example code provided in the repo.  If a user copies and pastes the example from the documentation, then they'll receive either:

```
AttributeError: 'User' object has no attribute 'id'
```
because the attribute name is mismatched,  OR a request will return:

```
{"exception":"InvalidRetrieveUserObject","reasons":"The retrieve_user
method should return either a dict or an object with a to_dict method."}
```
because the User object in the documentation does not have a method to allow to_dict to be called.

Just a documentation fix for knuckleheads like me, following along at home.
