### PR TITLE
make blueprint name configurable

### DIFF
--- a/sanic_jwt/configuration.py
+++ b/sanic_jwt/configuration.py
@@ -45,6 +45,7 @@ defaults = {
     "strict_slashes": False,
     "url_prefix": "/auth",
     "user_id": "user_id",
+    "blueprint_name": "auth_bp",
     "verify_exp": True
 }
 

--- a/sanic_jwt/initialization.py
+++ b/sanic_jwt/initialization.py
@@ -87,17 +87,17 @@ class Initialize:
                 setattr(self, class_name, value)
 
         app = self.__get_app(instance, app=app)
-        bp = self.__get_bp(instance)
 
         self.app = app
-        self.bp = bp
         self.kwargs = kwargs
         self.instance = instance
         self.config = None
+        self.bp = None
 
         self.__check_deprecated()
         self.__check_classes()
         self.__load_configuration()
+        self.__initialize_bp()
         self.__load_responses()
         self.__add_class_views()
         self.__add_endpoints()
@@ -290,17 +290,16 @@ class Initialize:
 
         raise exceptions.InitializationFailure
 
-    @staticmethod
-    def __get_bp(instance):
-        if isinstance(instance, Sanic):
-            return Blueprint("auth_bp")
+    def __initialize_bp(self):
+        if isinstance(self.instance, Sanic):
+            bp_name = self.config.blueprint_name()
+            self.bp = Blueprint(bp_name)
 
-        elif isinstance(instance, Blueprint):
-            return instance
+        elif isinstance(self.instance, Blueprint):
+            self.bp = self.instance
 
-        # I think this will never get here because `__get_app` get's called
-        # first and does the same check
-        raise exceptions.InitializationFailure  # noqa see line above
+        else:
+            raise exceptions.InitializationFailure  # noqa see line above
 
     def protected(self, *args, **kwargs):
         args = list(args)


### PR DESCRIPTION
## Goal
make blueprint name configurable. so we can add different auth instance for a same app.

## Approach
add a simple configure entry

## Open Questions and TODOs
- [X] https://github.com/ahopkins/sanic-jwt/issues/127
