### PR TITLE
#143 ensures that the token can not be empty

### DIFF
--- a/sanic_jwt/authentication.py
+++ b/sanic_jwt/authentication.py
@@ -256,7 +256,7 @@ class Authentication(BaseAuthentication):
             if header_prefix():
                 try:
                     prefix, token = header.split(" ")
-                    if prefix != header_prefix():
+                    if prefix != header_prefix() or not token:
                         raise Exception
 
                 except Exception:

--- a/sanic_jwt/authentication.py
+++ b/sanic_jwt/authentication.py
@@ -256,7 +256,7 @@ class Authentication(BaseAuthentication):
             if header_prefix():
                 try:
                     prefix, token = header.split(" ")
-                    if prefix != header_prefix() or not token:
+                    if prefix != header_prefix():
                         raise Exception
 
                 except Exception:
@@ -289,16 +289,15 @@ class Authentication(BaseAuthentication):
         """
         if self.config.cookie_set():
             token = self._get_token_from_cookies(request, refresh_token)
-            if token is not None:
+            if token:
                 return token
-
             else:
                 if self.config.cookie_strict():
                     raise exceptions.MissingAuthorizationCookie()
 
         if self.config.query_string_set():
             token = self._get_token_from_query_string(request, refresh_token)
-            if token is not None:
+            if token:
                 return token
 
             else:
@@ -306,7 +305,8 @@ class Authentication(BaseAuthentication):
                     raise exceptions.MissingAuthorizationQueryArg()
 
         token = self._get_token_from_headers(request, refresh_token)
-        if token is not None:
+
+        if token:
             return token
 
         raise exceptions.MissingAuthorizationHeader()

--- a/tests/test_endpoints_basic.py
+++ b/tests/test_endpoints_basic.py
@@ -71,6 +71,15 @@ def test_auth_verify_missing_token_debug(app):
     assert response.json.get("exception") == "MissingAuthorizationHeader"
     assert "Authorization header not present." in response.json.get("reasons")
 
+def test_auth_verify_invalid_token(app):
+    sanic_app, _ = app
+    _, response = sanic_app.test_client.get(
+        "/auth/verify",
+        headers={"Authorization": "Bearer "}
+    )
+    assert response.status == 400
+    assert response.json.get("exception") == "InvalidAuthorizationHeader"
+    assert "Authorization header is invalid." in response.json.get("reasons")
 
 def test_auth_refresh_not_found(app):
     sanic_app, _ = app

--- a/tests/test_endpoints_basic.py
+++ b/tests/test_endpoints_basic.py
@@ -81,6 +81,17 @@ def test_auth_verify_invalid_token(app):
     assert response.json.get("exception") == "InvalidAuthorizationHeader"
     assert "Authorization header is invalid." in response.json.get("reasons")
 
+def test_auth_verify_invalid_token(app):
+    sanic_app, _ = app
+    _, response = sanic_app.test_client.get(
+        "/auth/verify",
+        headers={"Authorization": "Bearer "}
+    )
+    assert response.status == 401
+    assert response.json.get("exception") == "MissingAuthorizationHeader"
+    assert "Authorization header not present." in response.json.get("reasons")
+
+
 def test_auth_refresh_not_found(app):
     sanic_app, _ = app
     _, response = sanic_app.test_client.post("/auth/refresh")

--- a/tests/test_endpoints_cookies.py
+++ b/tests/test_endpoints_cookies.py
@@ -365,3 +365,18 @@ class TestEndpointsCookies(object):
             sanicjwt.config.cookie_refresh_token_name(), None
         ) is None  # there is no new refresh token
         assert sanicjwt.config.cookie_refresh_token_name() not in response.json
+
+    def test_auth_verify_invalid_token(self, app_with_refresh_token):
+        sanic_app, sanicjwt = app_with_refresh_token
+
+        _, response = sanic_app.test_client.get(
+            "/auth/verify",
+            cookies={
+                sanicjwt.config.cookie_access_token_name(): ""
+            },
+        )
+        assert response.status == 401
+        assert response.json.get("exception") == "MissingAuthorizationCookie"
+        assert "Authorization cookie not present." in response.json.get(
+            "reasons"
+        )

--- a/tests/test_endpoints_query_string.py
+++ b/tests/test_endpoints_query_string.py
@@ -334,3 +334,15 @@ class TestEndpointsQueryString(object):
             sanicjwt.config.query_string_refresh_token_name(), None
         ) is None  # there is no new refresh token
         assert sanicjwt.config.query_string_refresh_token_name() not in response.json
+
+    def test_auth_verify_invalid_token(self, app_with_refresh_token):
+        sanic_app, sanicjwt = app_with_refresh_token
+
+        _, response = sanic_app.test_client.get(
+            "/auth/verify?{}=".format(sanicjwt.config.cookie_access_token_name()),
+        )
+        assert response.status == 401
+        assert response.json.get("exception") == "MissingAuthorizationQueryArg"
+        assert "Authorization query argument not present." in response.json.get(
+            "reasons"
+        )


### PR DESCRIPTION
## Goal
Security issue when using an empty token with the authorization header . See [issue](https://github.com/ahopkins/sanic-jwt/issues/143).

## Approach
Ensures that the token can't be empty when retrieved in `_get_token_from_headers()`
