### PR TITLE
1. fixing tests: add algorithms parameter to decode()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ from sanic_jwt.decorators import protected
 
 
 class User:
-
     def __init__(self, id, username, password):
         self.user_id = id
         self.username = username
@@ -40,15 +39,12 @@ def userid_table(users):
 
 @pytest.yield_fixture
 def authenticate(username_table):
-
     async def authenticate(request, *args, **kwargs):
         username = request.json.get("username", None)
         password = request.json.get("password", None)
 
         if not username or not password:
-            raise exceptions.AuthenticationFailed(
-                "Missing username or password."
-            )
+            raise exceptions.AuthenticationFailed("Missing username or password.")
 
         user = username_table.get(username, None)
         if user is None:
@@ -64,7 +60,6 @@ def authenticate(username_table):
 
 @pytest.yield_fixture
 def retrieve_user(userid_table):
-
     async def retrieve_user(request, payload, *args, **kwargs):
         if payload:
             user_id = payload.get("user_id", None)
@@ -117,11 +112,8 @@ def app_with_refresh_token(username_table, authenticate):
         sanic_app,
         authenticate=authenticate,
         refresh_token_enabled=True,
-        store_refresh_token=lambda user_id,
-        refresh_token,
-        request: True,
-        retrieve_refresh_token=lambda user_id,
-        request: True,
+        store_refresh_token=lambda user_id, refresh_token, request: True,
+        retrieve_refresh_token=lambda user_id, request: True,
     )
 
     yield (sanic_app, sanic_jwt)
@@ -178,9 +170,7 @@ def app_with_bp_setup_without_init(username_table, authenticate):
 def app_with_bp(app_with_bp_setup_without_init):
     sanic_app, sanic_bp = app_with_bp_setup_without_init
     sanic_jwt_init = Initialize(sanic_app, authenticate=authenticate)
-    sanic_jwt_init_bp = Initialize(
-        sanic_bp, app=sanic_app, authenticate=authenticate
-    )
+    sanic_jwt_init_bp = Initialize(sanic_bp, app=sanic_app, authenticate=authenticate)
     sanic_app.blueprint(sanic_bp)
 
     yield (sanic_app, sanic_jwt_init, sanic_bp, sanic_jwt_init_bp)
@@ -210,9 +200,7 @@ def app_with_extended_exp(username_table, authenticate):
 def app_with_leeway(username_table, authenticate):
 
     sanic_app = Sanic()
-    sanic_jwt = Initialize(
-        sanic_app, authenticate=authenticate, leeway=(60 * 5)
-    )
+    sanic_jwt = Initialize(sanic_app, authenticate=authenticate, leeway=(60 * 5))
 
     @sanic_app.route("/")
     async def helloworld(request):
@@ -231,10 +219,7 @@ def app_with_nbf(username_table, authenticate):
 
     sanic_app = Sanic()
     sanic_jwt = Initialize(
-        sanic_app,
-        authenticate=authenticate,
-        claim_nbf=True,
-        claim_nbf_delta=(60 * 5),
+        sanic_app, authenticate=authenticate, claim_nbf=True, claim_nbf_delta=(60 * 5)
     )
 
     @sanic_app.route("/")
@@ -253,9 +238,7 @@ def app_with_nbf(username_table, authenticate):
 def app_with_iat(username_table, authenticate):
 
     sanic_app = Sanic()
-    sanic_jwt = Initialize(
-        sanic_app, authenticate=authenticate, claim_iat=True
-    )
+    sanic_jwt = Initialize(sanic_app, authenticate=authenticate, claim_iat=True)
 
     @sanic_app.route("/")
     async def helloworld(request):
@@ -331,7 +314,6 @@ def app_with_retrieve_user(retrieve_user, authenticate):
 
 @pytest.yield_fixture
 def app_with_extra_verification(authenticate):
-
     def user2(payload):
         return payload.get("user_id") == 2
 
@@ -339,9 +321,7 @@ def app_with_extra_verification(authenticate):
 
     sanic_app = Sanic()
     sanic_jwt = Initialize(
-        sanic_app,
-        authenticate=authenticate,
-        extra_verifications=extra_verifications,
+        sanic_app, authenticate=authenticate, extra_verifications=extra_verifications
     )
 
     @sanic_app.route("/protected")
@@ -354,7 +334,6 @@ def app_with_extra_verification(authenticate):
 
 @pytest.yield_fixture
 def app_with_custom_claims(authenticate):
-
     class User2Claim(Claim):
         key = "username"
 

--- a/tests/test_async_options.py
+++ b/tests/test_async_options.py
@@ -16,7 +16,6 @@ ALL_METHODS = ["GET", "OPTIONS"]
 
 
 class TestMethodView(HTTPMethodView):
-
     async def options(self, *args, **kwargs):
         return text("ok")
 
@@ -33,7 +32,6 @@ bp.add_route(Tester.as_view(), "/test", methods=ALL_METHODS)
 
 
 class CustomAuth(Authentication):
-
     async def authenticate(self, request, *args, **kwargs):
         return {"username": "Rich", "password": "not secure"}
 
@@ -74,7 +72,9 @@ def test_async_options(app):
 
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
-    payload = jwt.decode(access_token, sanicjwt.config.secret())
+    payload = jwt.decode(
+        access_token, sanicjwt.config.secret(), algorithms=sanicjwt.config.algorithm()
+    )
 
     assert "extra_info" in payload
     assert payload.get("extra_info") == "awesome!"

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -6,13 +6,11 @@ from sanic_jwt import Authentication, exceptions, Initialize
 
 
 class WrongAuthentication(Authentication):
-
     async def build_payload(self, user, *args, **kwargs):
         return {"not_user_id": 1}
 
 
 class AnotherWrongAuthentication(Authentication):
-
     async def build_payload(self, user, *args, **kwargs):
         return list(range(5))
 
@@ -23,7 +21,6 @@ class AuthenticationWithNoMethod(Authentication):
 
 
 class AuthenticationInClassBody(Authentication):
-
     async def authenticate(self, request, *args, **kwargs):
         return {"user_id": 1}
 
@@ -68,11 +65,7 @@ def test_payload_without_correct_key():
 
     app = Sanic()
 
-    Initialize(
-        app,
-        authenticate=authenticate,
-        authentication_class=WrongAuthentication,
-    )
+    Initialize(app, authenticate=authenticate, authentication_class=WrongAuthentication)
 
     _, response = app.test_client.post(
         "/auth", json={"username": "user1", "password": "abcxyz"}
@@ -87,9 +80,7 @@ def test_payload_not_a_dict():
     app = Sanic()
 
     Initialize(
-        app,
-        authenticate=authenticate,
-        authentication_class=AnotherWrongAuthentication,
+        app, authenticate=authenticate, authentication_class=AnotherWrongAuthentication
     )
 
     _, response = app.test_client.post(
@@ -106,16 +97,13 @@ def test_wrong_header(app):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     assert response.status == 200
     assert access_token is not None
 
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Foobar {}".format(access_token)},
+        "/protected", headers={"Authorization": "Foobar {}".format(access_token)}
     )
 
     assert response.status == 401
@@ -132,9 +120,7 @@ def test_tricky_debug_option_true(app):
     @sanic_app.route("/another_protected")
     @sanic_jwt.protected(debug=lambda: True)
     def another_protected(request):
-        return json(
-            {"protected": True, "is_debug": request.app.auth.config.debug()}
-        )
+        return json({"protected": True, "is_debug": request.app.auth.config.debug()})
 
     # @sanic_app.exception(Exception)
     # def in_case_of_exception(request, exception):
@@ -146,16 +132,13 @@ def test_tricky_debug_option_true(app):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     assert response.status == 200
     assert access_token is not None
 
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -182,9 +165,7 @@ def test_tricky_debug_option_false(app):
     @sanic_app.route("/another_protected")
     @sanic_jwt.protected(debug=lambda: False)
     def another_protected(request):
-        return json(
-            {"protected": True, "is_debug": request.app.auth.config.debug()}
-        )
+        return json({"protected": True, "is_debug": request.app.auth.config.debug()})
 
     # @sanic_app.exception(Exception)
     # def in_case_of_exception(request, exception):
@@ -196,16 +177,13 @@ def test_tricky_debug_option_false(app):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     assert response.status == 200
     assert access_token is not None
 
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200

--- a/tests/test_authentication_custom.py
+++ b/tests/test_authentication_custom.py
@@ -6,9 +6,7 @@ from sanic_jwt import Authentication, Initialize
 
 @pytest.yield_fixture
 def app1():
-
     class MyAuthentication(Authentication):
-
         async def store_refresh_token(self, *args, **kwargs):
             return
 
@@ -25,18 +23,14 @@ def app1():
             return
 
     app = Sanic()
-    Initialize(
-        app, authentication_class=MyAuthentication, refresh_token_enabled=True
-    )
+    Initialize(app, authentication_class=MyAuthentication, refresh_token_enabled=True)
 
     yield app
 
 
 @pytest.yield_fixture
 def app2():
-
     class MyAuthentication(Authentication):
-
         async def store_refresh_token(self, *args, **kwargs):
             return
 
@@ -53,9 +47,7 @@ def app2():
             return {}
 
     app = Sanic()
-    Initialize(
-        app, authentication_class=MyAuthentication, refresh_token_enabled=True
-    )
+    Initialize(app, authentication_class=MyAuthentication, refresh_token_enabled=True)
 
     yield app
 
@@ -100,9 +92,7 @@ def test_verify_no_auth_header(app1):
 
 
 def test_refresh_no_valid_object(app1):
-    _, response = app1.test_client.post(
-        "/auth/refresh", json={"not": "important"}
-    )
+    _, response = app1.test_client.post("/auth/refresh", json={"not": "important"})
 
     assert response.status == 401
     assert response.json.get("exception") == "Unauthorized"
@@ -110,9 +100,7 @@ def test_refresh_no_valid_object(app1):
 
 
 def test_refresh_no_valid_dict(app2):
-    _, response = app2.test_client.post(
-        "/auth/refresh", json={"not": "important"}
-    )
+    _, response = app2.test_client.post("/auth/refresh", json={"not": "important"})
 
     assert response.status == 401
     assert response.json.get("exception") == "Unauthorized"

--- a/tests/test_complete_authentication.py
+++ b/tests/test_complete_authentication.py
@@ -14,17 +14,13 @@ def cache():
 
 @pytest.yield_fixture
 def my_authentication_class(users, cache):
-
     class MyAuthentication(Authentication):
-
         async def authenticate(self, request, *args, **kwargs):
             username = request.json.get("username", None)
             password = request.json.get("password", None)
 
             if not username or not password:
-                raise exceptions.AuthenticationFailed(
-                    "Missing username or password."
-                )
+                raise exceptions.AuthenticationFailed("Missing username or password.")
 
             user = None
 
@@ -41,9 +37,7 @@ def my_authentication_class(users, cache):
 
             return user
 
-        async def store_refresh_token(
-            self, user_id, refresh_token, *args, **kwargs
-        ):
+        async def store_refresh_token(self, user_id, refresh_token, *args, **kwargs):
             key = "refresh_token_{user_id}".format(user_id=user_id)
             cache[key] = refresh_token
 
@@ -99,12 +93,8 @@ def app_full_auth_cls(sanic_app, my_authentication_class):
 
 
 @pytest.yield_fixture
-def app_full_bytes_refresh_token(
-    users, sanic_app, my_authentication_class, cache
-):
-
+def app_full_bytes_refresh_token(users, sanic_app, my_authentication_class, cache):
     class MyAuthentication(my_authentication_class):
-
         async def retrieve_refresh_token(self, user_id, *args, **kwargs):
             key = "refresh_token_{user_id}".format(user_id=user_id)
             token = cache.get(key, None).encode("utf-8")
@@ -112,9 +102,7 @@ def app_full_bytes_refresh_token(
             return token
 
     sanicjwt = Initialize(
-        sanic_app,
-        authentication_class=MyAuthentication,
-        refresh_token_enabled=True,
+        sanic_app, authentication_class=MyAuthentication, refresh_token_enabled=True
     )
 
     yield (sanic_app, sanicjwt)
@@ -133,29 +121,27 @@ def test_authentication_all_methods(app_full_auth_cls):
     assert sanicjwt.config.refresh_token_name() in response.json
 
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
-    refresh_token = response.json.get(
-        sanicjwt.config.refresh_token_name(), None
-    )
+    refresh_token = response.json.get(sanicjwt.config.refresh_token_name(), None)
 
     assert access_token is not None
     assert refresh_token is not None
 
-    payload = jwt.decode(access_token, sanicjwt.config.secret())
+    payload = jwt.decode(
+        access_token, sanicjwt.config.secret(), algorithms=sanicjwt.config.algorithm()
+    )
 
     assert "foo" in payload
     assert payload.get("foo") == "bar"
 
     _, response = app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
     assert response.json.get("protected") is True
 
     _, response = app.test_client.get(
-        "/auth/verify",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/auth/verify", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -173,15 +159,13 @@ def test_authentication_all_methods(app_full_auth_cls):
         json={sanicjwt.config.refresh_token_name(): refresh_token},
     )
 
-    new_access_token = response.json.get(
-        sanicjwt.config.access_token_name(), None
-    )
+    new_access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
     assert response.status == 200
     assert new_access_token is not None
-    assert response.json.get(
-        sanicjwt.config.refresh_token_name(), None
-    ) is None  # there is no new refresh token
+    assert (
+        response.json.get(sanicjwt.config.refresh_token_name(), None) is None
+    )  # there is no new refresh token
     assert sanicjwt.config.refresh_token_name() not in response.json
 
 
@@ -198,9 +182,7 @@ def test_refresh_token_with_expired_access_token(app_full_auth_cls):
     assert sanicjwt.config.refresh_token_name() in response.json
 
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
-    refresh_token = response.json.get(
-        sanicjwt.config.refresh_token_name(), None
-    )
+    refresh_token = response.json.get(sanicjwt.config.refresh_token_name(), None)
 
     assert access_token is not None
     assert refresh_token is not None
@@ -212,15 +194,13 @@ def test_refresh_token_with_expired_access_token(app_full_auth_cls):
             json={sanicjwt.config.refresh_token_name(): refresh_token},
         )
 
-        new_access_token = response.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        new_access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
         assert response.status == 200
         assert new_access_token is not None
-        assert response.json.get(
-            sanicjwt.config.refresh_token_name(), None
-        ) is None  # there is no new refresh token
+        assert (
+            response.json.get(sanicjwt.config.refresh_token_name(), None) is None
+        )  # there is no new refresh token
         assert sanicjwt.config.refresh_token_name() not in response.json
 
 
@@ -236,9 +216,7 @@ def test_authentication_cross_tokens(app_full_auth_cls):
     assert sanicjwt.config.access_token_name() in response.json
     assert sanicjwt.config.refresh_token_name() in response.json
 
-    access_token_u1 = response.json.get(
-        sanicjwt.config.access_token_name(), None
-    )
+    access_token_u1 = response.json.get(sanicjwt.config.access_token_name(), None)
 
     _, response = app.test_client.post(
         "/auth", json={"username": "user2", "password": "abcxyz"}
@@ -248,9 +226,7 @@ def test_authentication_cross_tokens(app_full_auth_cls):
     assert sanicjwt.config.access_token_name() in response.json
     assert sanicjwt.config.refresh_token_name() in response.json
 
-    refresh_token_u2 = response.json.get(
-        sanicjwt.config.refresh_token_name(), None
-    )
+    refresh_token_u2 = response.json.get(sanicjwt.config.refresh_token_name(), None)
 
     _, response = app.test_client.post(
         "/auth/refresh",
@@ -276,29 +252,27 @@ def test_authentication_with_bytes_refresh_token(app_full_bytes_refresh_token):
     assert sanicjwt.config.refresh_token_name() in response.json
 
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
-    refresh_token = response.json.get(
-        sanicjwt.config.refresh_token_name(), None
-    )
+    refresh_token = response.json.get(sanicjwt.config.refresh_token_name(), None)
 
     assert access_token is not None
     assert refresh_token is not None
 
-    payload = jwt.decode(access_token, sanicjwt.config.secret())
+    payload = jwt.decode(
+        access_token, sanicjwt.config.secret(), algorithms=sanicjwt.config.algorithm()
+    )
 
     assert "foo" in payload
     assert payload.get("foo") == "bar"
 
     _, response = app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
     assert response.json.get("protected") is True
 
     _, response = app.test_client.get(
-        "/auth/verify",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/auth/verify", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -316,13 +290,11 @@ def test_authentication_with_bytes_refresh_token(app_full_bytes_refresh_token):
         json={sanicjwt.config.refresh_token_name(): refresh_token},
     )
 
-    new_access_token = response.json.get(
-        sanicjwt.config.access_token_name(), None
-    )
+    new_access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
     assert response.status == 200
     assert new_access_token is not None
-    assert response.json.get(
-        sanicjwt.config.refresh_token_name(), None
-    ) is None  # there is no new refresh token
+    assert (
+        response.json.get(sanicjwt.config.refresh_token_name(), None) is None
+    )  # there is no new refresh token
     assert sanicjwt.config.refresh_token_name() not in response.json

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -78,7 +78,6 @@ def test_configuration_initialize_class_with_getter():
     app = Sanic()
 
     class MyConfig(Configuration):
-
         def set_access_token_name(self):
             return "return-level"
 
@@ -94,13 +93,10 @@ def test_configuration_initialize_class_as_argument():
     app = Sanic()
 
     class MyConfig(Configuration):
-
         def set_access_token_name(self):
             return "return-level"
 
-    sanicjwt = Initialize(
-        app, configuration_class=MyConfig, authenticate=lambda: True
-    )
+    sanicjwt = Initialize(app, configuration_class=MyConfig, authenticate=lambda: True)
 
     assert sanicjwt.config.access_token_name() == "return-level"
 
@@ -111,9 +107,7 @@ def test_configuration_warning_non_callable(caplog):
     class MyConfig(Configuration):
         set_access_token_name = "return-level"
 
-    sanicjwt = Initialize(
-        app, configuration_class=MyConfig, authenticate=lambda: True
-    )
+    sanicjwt = Initialize(app, configuration_class=MyConfig, authenticate=lambda: True)
 
     for record in caplog.records:
         if record.levelname == "WARNING":
@@ -143,7 +137,6 @@ def test_configuration_dynamic_config():
     auth_header_key = "x-authorization-header"
 
     class MyConfig(Configuration):
-
         def get_authorization_header(self, request):
             if auth_header_key in request.headers:
                 return request.headers.get(auth_header_key)
@@ -153,9 +146,7 @@ def test_configuration_dynamic_config():
     async def authenticate(request, *args, **kwargs):
         return {"user_id": 1}
 
-    sanicjwt = Initialize(
-        app, configuration_class=MyConfig, authenticate=authenticate
-    )
+    sanicjwt = Initialize(app, configuration_class=MyConfig, authenticate=authenticate)
 
     @app.route("/protected")
     @sanicjwt.protected()
@@ -183,9 +174,7 @@ def test_configuration_dynamic_config():
     _, response = app.test_client.get(
         "/protected",
         headers={
-            sanicjwt.config.authorization_header(): "Bearer {}".format(
-                access_token
-            )
+            sanicjwt.config.authorization_header(): "Bearer {}".format(access_token)
         },
     )
 
@@ -252,8 +241,7 @@ def test_empty_string_authorization_prefix():
     assert response.json.get("protected") == "yes"
 
     _, response = app.test_client.get(
-        "/protected",
-        headers={sanicjwt.config.authorization_header(): access_token},
+        "/protected", headers={sanicjwt.config.authorization_header(): access_token}
     )
 
     assert response.status == 200
@@ -270,9 +258,7 @@ def test_configuration_custom_class_and_config_item():
     class MyConfig(Configuration):
         access_token_name = ConfigItem("config-item-level")
 
-    sanicjwt = Initialize(
-        app, configuration_class=MyConfig, authenticate=lambda: True
-    )
+    sanicjwt = Initialize(app, configuration_class=MyConfig, authenticate=lambda: True)
 
     assert sanicjwt.config.access_token_name() == "config-item-level"
 
@@ -281,13 +267,10 @@ def test_configuration_custom_class_and_config_item_as_method():
     app = Sanic()
 
     class MyConfig(Configuration):
-
         def set_access_token_name(self):
             return ConfigItem("config-item-function-level")
 
-    sanicjwt = Initialize(
-        app, configuration_class=MyConfig, authenticate=lambda: True
-    )
+    sanicjwt = Initialize(app, configuration_class=MyConfig, authenticate=lambda: True)
 
     assert sanicjwt.config.access_token_name() == "config-item-function-level"
 
@@ -298,9 +281,7 @@ def test_configuration_invalid_claim():
     class MyConfig(Configuration):
         claim_foo = "bar"
 
-    sanicjwt = Initialize(
-        app, configuration_class=MyConfig, authenticate=lambda: True
-    )
+    sanicjwt = Initialize(app, configuration_class=MyConfig, authenticate=lambda: True)
 
     assert "claim_foo" not in sanicjwt.config._all_config_keys
 

--- a/tests/test_convenience_methods.py
+++ b/tests/test_convenience_methods.py
@@ -14,13 +14,10 @@ def test_is_authenticated_on_properly_authenticated_request(app):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     request, _ = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     is_authenticated = sanic_app.auth.is_authenticated(request)
@@ -35,13 +32,10 @@ def test_extract_user_id(app):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     request, _ = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     user_id = sanic_app.auth.extract_user_id(request)

--- a/tests/test_custom_claims.py
+++ b/tests/test_custom_claims.py
@@ -20,10 +20,10 @@ def test_custom_claims_payload(app_with_custom_claims):
     _, response = sanic_app.test_client.post(
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+    payload = jwt.decode(
+        access_token, sanic_jwt.config.secret(), algorithms=sanic_jwt.config.algorithm()
     )
-    payload = jwt.decode(access_token, sanic_jwt.config.secret())
 
     assert isinstance(payload, dict)
     assert "username" in payload
@@ -36,12 +36,9 @@ def test_custom_claims(app_with_custom_claims):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 401
@@ -51,19 +48,15 @@ def test_custom_claims(app_with_custom_claims):
         "/auth", json={"username": "user2", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
 
 
 def test_custom_claims_bad(authenticate):
-
     class MissingVerifyClaim(Claim):
         key = "username"
 
@@ -77,7 +70,6 @@ def test_custom_claims_bad(authenticate):
             return True
 
     class MissingKeyClaim(Claim):
-
         def setup(self, payload, user):
             return user.username
 
@@ -87,28 +79,21 @@ def test_custom_claims_bad(authenticate):
     with pytest.raises(exceptions.InvalidCustomClaim):
         sanic_app = Sanic()
         Initialize(
-            sanic_app,
-            authenticate=authenticate,
-            custom_claims=[MissingVerifyClaim],
+            sanic_app, authenticate=authenticate, custom_claims=[MissingVerifyClaim]
         )
     with pytest.raises(exceptions.InvalidCustomClaim):
         sanic_app = Sanic()
         Initialize(
-            sanic_app,
-            authenticate=authenticate,
-            custom_claims=[MissingSetupClaim],
+            sanic_app, authenticate=authenticate, custom_claims=[MissingSetupClaim]
         )
     with pytest.raises(exceptions.InvalidCustomClaim):
         sanic_app = Sanic()
         Initialize(
-            sanic_app,
-            authenticate=authenticate,
-            custom_claims=[MissingKeyClaim],
+            sanic_app, authenticate=authenticate, custom_claims=[MissingKeyClaim]
         )
 
 
 def test_custom_claim_non_boolean_return():
-
     class CustomClaim(Claim):
         key = "foo"
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -34,16 +34,14 @@ def test_forgotten_initialized_on_protected():
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
     _, response = app.test_client.get(
-        "/test/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/test/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 500
     assert response.json.get("exception") == "SanicJWTException"
 
     _, response = app.test_client.get(
-        "/test/scoped",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/test/scoped", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 500
@@ -75,9 +73,7 @@ def test_inject_user_regular(app_with_retrieve_user):
     async def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     _, response = sanic_app.test_client.get(
         "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
@@ -86,8 +82,7 @@ def test_inject_user_regular(app_with_retrieve_user):
     assert response.json.get("me").get("user_id") == 1
 
     _, response = sanic_app.test_client.get(
-        "/protected/user",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
     )
     assert response.status == 200
     assert response.json.get("user_id") == 1
@@ -105,9 +100,7 @@ def test_inject_user_on_instance(app_with_retrieve_user):
     async def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     _, response = sanic_app.test_client.get(
         "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
@@ -116,8 +109,7 @@ def test_inject_user_on_instance(app_with_retrieve_user):
     assert response.json.get("me").get("user_id") == 1
 
     _, response = sanic_app.test_client.get(
-        "/protected/user",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
     )
     assert response.status == 200
     assert response.json.get("user_id") == 1
@@ -135,9 +127,7 @@ def test_inject_user_on_instance_bp(app_with_retrieve_user):
     async def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     _, response = sanic_app.test_client.get(
         "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
@@ -146,8 +136,7 @@ def test_inject_user_on_instance_bp(app_with_retrieve_user):
     assert response.json.get("me").get("user_id") == 1
 
     _, response = sanic_app.test_client.get(
-        "/protected/user",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
     )
     assert response.status == 200
     assert response.json.get("user_id") == 1
@@ -165,9 +154,7 @@ def test_inject_user_on_instance_non_async(app_with_retrieve_user):
     def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     _, response = sanic_app.test_client.get(
         "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
@@ -176,15 +163,13 @@ def test_inject_user_on_instance_non_async(app_with_retrieve_user):
     assert response.json.get("me").get("user_id") == 1
 
     _, response = sanic_app.test_client.get(
-        "/protected/user",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
     )
     assert response.status == 200
     assert response.json.get("user_id") == 1
 
 
 def test_inject_user_with_auth_mode_off(app_with_retrieve_user):
-
     async def retrieve_user(request, payload, *args, **kwargs):
         return {"user_id": 123}
 
@@ -204,13 +189,10 @@ def test_inject_user_with_auth_mode_off(app_with_retrieve_user):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     _, response = microservice_app.test_client.get(
-        "/protected/user",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200

--- a/tests/test_decorators_override_config.py
+++ b/tests/test_decorators_override_config.py
@@ -50,7 +50,9 @@ def test_decorators_override_configuration_defaults():
 
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
-    payload = jwt.decode(access_token, sanicjwt.config.secret())
+    payload = jwt.decode(
+        access_token, sanicjwt.config.secret(), algorithms=sanicjwt.config.algorithm()
+    )
     exp = payload.get("exp", None)
 
     assert "exp" in payload

--- a/tests/test_endpoints_async_methods.py
+++ b/tests/test_endpoints_async_methods.py
@@ -11,7 +11,6 @@ from sanic_jwt.decorators import protected
 
 
 class User(object):
-
     def __init__(self, id, username, password):
         self.id = id
         self.username = username
@@ -38,9 +37,7 @@ def app_with_async_methods():
         password = request.json.get("password", None)
 
         if not username or not password:
-            raise exceptions.AuthenticationFailed(
-                "Missing username or password."
-            )
+            raise exceptions.AuthenticationFailed("Missing username or password.")
 
         user = None
 
@@ -108,7 +105,6 @@ def app_with_async_methods():
 
 
 class TestEndpointsAsync(object):
-
     @pytest.yield_fixture
     def authenticated_response(self, app_with_async_methods):
         app, sanicjwt = app_with_async_methods
@@ -124,17 +120,14 @@ class TestEndpointsAsync(object):
         assert response.status == 200
         assert response.json.get("hello") == "world"
 
-    def test_protected_endpoint(
-        self, app_with_async_methods, authenticated_response
-    ):
+    def test_protected_endpoint(self, app_with_async_methods, authenticated_response):
         app, sanicjwt = app_with_async_methods
         access_token = authenticated_response.json.get(
             sanicjwt.config.access_token_name(), None
         )
 
         _, response = app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -147,16 +140,13 @@ class TestEndpointsAsync(object):
         )
 
         _, response = app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
         assert response.json.get("me").get("user_id") == "0x1"
 
-    def test_refresh_token_async(
-        self, app_with_async_methods, authenticated_response
-    ):
+    def test_refresh_token_async(self, app_with_async_methods, authenticated_response):
         app, sanicjwt = app_with_async_methods
         access_token = authenticated_response.json.get(
             sanicjwt.config.access_token_name(), None
@@ -174,13 +164,11 @@ class TestEndpointsAsync(object):
         assert response.json is not None
         assert sanicjwt.config.access_token_name() in response.json
 
-        new_access_token = response.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        new_access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
         assert response.status == 200
         assert new_access_token is not None
-        assert response.json.get(
-            sanicjwt.config.refresh_token_name(), None
-        ) is None  # there is no new refresh token
+        assert (
+            response.json.get(sanicjwt.config.refresh_token_name(), None) is None
+        )  # there is no new refresh token
         assert sanicjwt.config.refresh_token_name() not in response.json

--- a/tests/test_endpoints_auth.py
+++ b/tests/test_endpoints_auth.py
@@ -14,11 +14,12 @@ def access_token(app):
 @pytest.fixture
 def payload(app, access_token):
     _, sanic_jwt = app
-    return jwt.decode(access_token, sanic_jwt.config.secret())
+    return jwt.decode(
+        access_token, sanic_jwt.config.secret(), algorithms=sanicjwt.config.algorithm()
+    )
 
 
 class TestEndpointsAuth:
-
     def dispatch(self, path, method, app, access_token):
         sanic_app, sanic_jwt = app
         header_token = "{} {}".format(
@@ -26,8 +27,7 @@ class TestEndpointsAuth:
         )
         method = getattr(sanic_app.test_client, method)
         request, response = method(
-            path,
-            headers={sanic_jwt.config.authorization_header(): header_token},
+            path, headers={sanic_jwt.config.authorization_header(): header_token}
         )
         return request, response
 

--- a/tests/test_endpoints_auth_on_url_prefix.py
+++ b/tests/test_endpoints_auth_on_url_prefix.py
@@ -12,7 +12,6 @@ def access_token(app_with_url_prefix):
 
 
 class TestEndpointsAuth:
-
     def dispatch(self, path, method, app_with_url_prefix, access_token):
         sanic_app, sanic_jwt = app_with_url_prefix
         header_token = "{} {}".format(
@@ -20,8 +19,7 @@ class TestEndpointsAuth:
         )
         method = getattr(sanic_app.test_client, method)
         request, response = method(
-            path,
-            headers={sanic_jwt.config.authorization_header(): header_token},
+            path, headers={sanic_jwt.config.authorization_header(): header_token}
         )
         return request, response
 
@@ -37,9 +35,7 @@ class TestEndpointsAuth:
         assert response.json.get("valid") is True
 
     def test_protected(self, app_with_url_prefix, access_token):
-        _, response = self.get(
-            "/protected/", app_with_url_prefix, access_token
-        )
+        _, response = self.get("/protected/", app_with_url_prefix, access_token)
 
         assert response.status == 200
         assert response.json.get("protected") is True

--- a/tests/test_endpoints_basic.py
+++ b/tests/test_endpoints_basic.py
@@ -36,10 +36,10 @@ def test_auth_proper_credentials(app):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+    payload = jwt.decode(
+        access_token, sanic_jwt.config.secret(), algorithms=sanic_jwt.config.algorithm()
     )
-    payload = jwt.decode(access_token, sanic_jwt.config.secret())
 
     assert response.status == 200
     assert access_token is not None
@@ -48,8 +48,7 @@ def test_auth_proper_credentials(app):
     assert "exp" in payload
 
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
     assert response.status == 200
 
@@ -114,8 +113,7 @@ def test_auth_refresh_not_enabled(app_with_refresh_token):
     assert "Authorization header not present." in response.json.get("reasons")
 
     _, response = sanic_app.test_client.post(
-        "/auth/refresh",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/auth/refresh", headers={"Authorization": "Bearer {}".format(access_token)}
     )
     message = "Refresh tokens have not been enabled properly."
     "Perhaps you forgot to initialize with a retrieve_user handler?"

--- a/tests/test_endpoints_cbv.py
+++ b/tests/test_endpoints_cbv.py
@@ -9,7 +9,6 @@ from sanic.views import HTTPMethodView
 
 
 class User(object):
-
     def __init__(self, id, username, password):
         self.id = id
         self.username = username
@@ -48,7 +47,6 @@ sanic_jwt = Initialize(sanic_app, authenticate=authenticate)
 
 
 class PublicView(HTTPMethodView):
-
     def get(self, request):
         return json({"hello": "world"})
 
@@ -65,7 +63,6 @@ sanic_app.add_route(ProtectedView.as_view(), "/protected")
 
 
 class TestEndpointsCBV(object):
-
     def test_unprotected(self):
         _, response = sanic_app.test_client.get("/")
         assert response.status == 200
@@ -74,9 +71,7 @@ class TestEndpointsCBV(object):
         _, response = sanic_app.test_client.get("/protected")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
     def test_auth_invalid_method(self):
         _, response = sanic_app.test_client.get("/auth")
@@ -88,10 +83,12 @@ class TestEndpointsCBV(object):
             "/auth", json={"username": "user1", "password": "abcxyz"}
         )
 
-        access_token = response.json.get(
-            sanic_jwt.config.access_token_name(), None
+        access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+        payload = jwt.decode(
+            access_token,
+            sanic_jwt.config.secret(),
+            algorithms=sanic_jwt.config.algorithm(),
         )
-        payload = jwt.decode(access_token, sanic_jwt.config.secret())
 
         assert response.status == 200
         assert access_token is not None
@@ -100,7 +97,6 @@ class TestEndpointsCBV(object):
         assert "exp" in payload
 
         _, response = sanic_app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
         assert response.status == 200

--- a/tests/test_endpoints_cookies.py
+++ b/tests/test_endpoints_cookies.py
@@ -66,7 +66,6 @@ def app_with_refresh_token(users, authenticate):
 
 
 class TestEndpointsCookies(object):
-
     @pytest.yield_fixture
     def authenticated_response(self, app_with_refresh_token):
         sanic_app, sanicjwt = app_with_refresh_token
@@ -83,9 +82,7 @@ class TestEndpointsCookies(object):
         key = sanicjwt.config.cookie_access_token_name()
         # print(key)
         # print(authenticated_response.cookies.values())
-        access_token_from_cookie = authenticated_response.cookies.get(
-            key, None
-        )
+        access_token_from_cookie = authenticated_response.cookies.get(key, None)
 
         assert access_token_from_cookie is not None
 
@@ -98,10 +95,14 @@ class TestEndpointsCookies(object):
         assert access_token_from_json is not None
 
         payload_cookie = jwt.decode(
-            access_token_from_cookie, sanicjwt.config.secret()
+            access_token_from_cookie,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
         )
         payload_json = jwt.decode(
-            access_token_from_json, sanicjwt.config.secret()
+            access_token_from_json,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
         )
 
         assert access_token_from_json is not None
@@ -115,11 +116,11 @@ class TestEndpointsCookies(object):
     ):
         sanic_app, sanicjwt = app_with_refresh_token
         key = sanicjwt.config.cookie_access_token_name()
-        access_token_from_cookie = authenticated_response.cookies.get(
-            key
-        ).value
+        access_token_from_cookie = authenticated_response.cookies.get(key).value
         payload_cookie = jwt.decode(
-            access_token_from_cookie, sanicjwt.config.secret()
+            access_token_from_cookie,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
         )
 
         assert isinstance(payload_cookie, dict)
@@ -136,12 +137,8 @@ class TestEndpointsCookies(object):
         assert response.json.get("me") is not None
         assert sanicjwt.config.user_id() in response.json.get("me")
 
-        user_id_from_me = response.json.get("me").get(
-            sanicjwt.config.user_id()
-        )
-        user_id_from_payload_cookie = payload_cookie.get(
-            sanicjwt.config.user_id()
-        )
+        user_id_from_me = response.json.get("me").get(sanicjwt.config.user_id())
+        user_id_from_payload_cookie = payload_cookie.get(sanicjwt.config.user_id())
 
         assert response.status == 200
         assert user_id_from_me == user_id_from_payload_cookie
@@ -151,11 +148,11 @@ class TestEndpointsCookies(object):
     ):
         sanic_app, sanicjwt = app_with_refresh_token
         key = sanicjwt.config.cookie_access_token_name()
-        access_token_from_cookie = authenticated_response.cookies.get(
-            key
-        ).value
+        access_token_from_cookie = authenticated_response.cookies.get(key).value
         payload_cookie = jwt.decode(
-            access_token_from_cookie, sanicjwt.config.secret()
+            access_token_from_cookie,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
         )
 
         assert isinstance(payload_cookie, dict)
@@ -163,42 +160,30 @@ class TestEndpointsCookies(object):
 
         _, response = sanic_app.test_client.get(
             "/auth/me",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_cookie)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_cookie)},
         )
 
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization cookie not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization cookie not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get(
             "/protected",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_cookie)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_cookie)},
         )
 
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization cookie not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization cookie not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get(
             "/auth/verify",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_cookie)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_cookie)},
         )
 
         assert response.status == 401
         assert response.json.get("exception") == "MissingAuthorizationCookie"
-        assert "Authorization cookie not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization cookie not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get(
             "/auth/me",
@@ -228,11 +213,11 @@ class TestEndpointsCookies(object):
         sanic_app.auth.config.cookie_strict.update(False)
 
         key = sanicjwt.config.cookie_access_token_name()
-        access_token_from_cookie = authenticated_response.cookies.get(
-            key
-        ).value
+        access_token_from_cookie = authenticated_response.cookies.get(key).value
         payload_cookie = jwt.decode(
-            access_token_from_cookie, sanicjwt.config.secret()
+            access_token_from_cookie,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
         )
 
         assert isinstance(payload_cookie, dict)
@@ -240,39 +225,30 @@ class TestEndpointsCookies(object):
 
         _, response = sanic_app.test_client.get(
             "/auth/me",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_cookie)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_cookie)},
         )
 
         assert response.status == 200
         assert response.json.get("me") is not None
-        assert (
-            response.json.get("me").get(sanicjwt.config.user_id())
-            == payload_cookie.get(sanicjwt.config.user_id())
-        )
+        assert response.json.get("me").get(
+            sanicjwt.config.user_id()
+        ) == payload_cookie.get(sanicjwt.config.user_id())
 
         _, response = sanic_app.test_client.get(
             "/protected",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_cookie)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_cookie)},
         )
 
         assert response.status == 200
 
         _, response = sanic_app.test_client.get(
             "/auth/verify",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_cookie)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_cookie)},
         )
 
         _, response = sanic_app.test_client.get(
             "/protected",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_cookie)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_cookie)},
         )
 
         assert response.status == 200
@@ -304,14 +280,12 @@ class TestEndpointsCookies(object):
         assert response.status == 200
         assert response.json is not None
 
-        new_access_token = response.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        new_access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
         assert new_access_token is not None
-        assert response.json.get(
-            sanicjwt.config.cookie_refresh_token_name(), None
-        ) is None  # there is no new refresh token
+        assert (
+            response.json.get(sanicjwt.config.cookie_refresh_token_name(), None) is None
+        )  # there is no new refresh token
         assert sanicjwt.config.cookie_refresh_token_name() not in response.json
 
         sanicjwt.config.debug.update(False)
@@ -323,9 +297,7 @@ class TestEndpointsCookies(object):
 
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization cookie not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization cookie not present." in response.json.get("reasons")
 
         sanicjwt.config.debug.update(True)
         _, response = sanic_app.test_client.post(
@@ -336,9 +308,7 @@ class TestEndpointsCookies(object):
 
         assert response.status == 400
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization cookie not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization cookie not present." in response.json.get("reasons")
 
     def test_refresh_token_with_cookies_not_strict(
         self, app_with_refresh_token, authenticated_response
@@ -361,20 +331,17 @@ class TestEndpointsCookies(object):
         )
 
         assert response.status == 200
-        assert response.json.get(
-            sanicjwt.config.cookie_refresh_token_name(), None
-        ) is None  # there is no new refresh token
+        assert (
+            response.json.get(sanicjwt.config.cookie_refresh_token_name(), None) is None
+        )  # there is no new refresh token
         assert sanicjwt.config.cookie_refresh_token_name() not in response.json
 
     def test_auth_verify_invalid_token(self, app_with_refresh_token):
         sanic_app, sanicjwt = app_with_refresh_token
 
         _, response = sanic_app.test_client.get(
-            "/auth/verify",
-            cookies={sanicjwt.config.cookie_access_token_name(): ""},
+            "/auth/verify", cookies={sanicjwt.config.cookie_access_token_name(): ""}
         )
         assert response.status == 401
         assert response.json.get("exception") == "MissingAuthorizationCookie"
-        assert "Authorization cookie not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization cookie not present." in response.json.get("reasons")

--- a/tests/test_endpoints_custom.py
+++ b/tests/test_endpoints_custom.py
@@ -7,31 +7,26 @@ msg = "custom {} endpoint"
 
 
 class MyAuthenticateEndpoint(BaseEndpoint):
-
     async def post(self, request, *args, **kwargs):
         return json({"hello": msg.format("authentication")})
 
 
 class RetrieveUserEndpoint(BaseEndpoint):
-
     async def get(self, request, *args, **kwargs):
         return json({"hello": msg.format("retrieve user")})
 
 
 class VerifyEndpoint(BaseEndpoint):
-
     async def get(self, request, *args, **kwargs):
         return json({"hello": msg.format("verify")})
 
 
 class RefreshEndpoint(BaseEndpoint):
-
     async def post(self, request, *args, **kwargs):
         return json({"hello": msg.format("refresh")})
 
 
 class MyAuthentication(Authentication):
-
     async def store_refresh_token(self, *args, **kwargs):
         return
 
@@ -84,9 +79,7 @@ def test_custom_endpoints_as_args():
     assert response.status == 200
     assert response.json.get("hello") == msg.format("verify")
 
-    _, response = app.test_client.post(
-        "/auth/refresh", json={"not": "important"}
-    )
+    _, response = app.test_client.post("/auth/refresh", json={"not": "important"})
 
     assert response.status == 200
     assert response.json.get("hello") == msg.format("refresh")

--- a/tests/test_endpoints_dict_first.py
+++ b/tests/test_endpoints_dict_first.py
@@ -5,7 +5,6 @@ from sanic_jwt import exceptions, Initialize
 
 
 class MyCustomDict(dict):
-
     async def to_dict(self):
         raise Exception("i am not supposed to be called")
 
@@ -23,9 +22,7 @@ def app_with_dict_test():
         password = request.json.get("password", None)
 
         if not username or not password:
-            raise exceptions.AuthenticationFailed(
-                "Missing username or password."
-            )
+            raise exceptions.AuthenticationFailed("Missing username or password.")
 
         user = the_user
 
@@ -40,7 +37,6 @@ def app_with_dict_test():
 
 
 class TestEndpointsAsync(object):
-
     @pytest.yield_fixture
     def authenticated_response(self, app_with_dict_test):
         app, sanicjwt = app_with_dict_test
@@ -57,8 +53,7 @@ class TestEndpointsAsync(object):
         )
 
         _, response = app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200

--- a/tests/test_endpoints_extra.py
+++ b/tests/test_endpoints_extra.py
@@ -5,7 +5,6 @@ from sanic_jwt import BaseEndpoint
 
 
 class MagicLoginHandler(BaseEndpoint):
-
     async def options(self, request):
         return response.text("", status=204)
 
@@ -22,7 +21,8 @@ initialize(
     authenticate=lambda: True,
     class_views=[
         (
-            "/magic-login", MagicLoginHandler
+            "/magic-login",
+            MagicLoginHandler,
         )  # The path will be relative to the url prefix
         # (which defaults to /auth)
     ],
@@ -30,7 +30,6 @@ initialize(
 
 
 class TestEndpointsExtra(object):
-
     def dispatch(self, path, method):
         method = getattr(app.test_client, method)
         request, response = method(path)

--- a/tests/test_endpoints_init_on_bp_and_app.py
+++ b/tests/test_endpoints_init_on_bp_and_app.py
@@ -57,33 +57,23 @@ def test_protected_blueprints():
     assert response1.status == 200
     assert response2.status == 200
 
-    access_token_1 = response1.json.get(
-        sanicjwt1.config.access_token_name(), None
-    )
-    access_token_2 = response2.json.get(
-        sanicjwt2.config.access_token_name(), None
-    )
+    access_token_1 = response1.json.get(sanicjwt1.config.access_token_name(), None)
+    access_token_2 = response2.json.get(sanicjwt2.config.access_token_name(), None)
 
     assert access_token_1 is not None
     assert access_token_2 is not None
 
-    wrong_token_grab_1 = response1.json.get(
-        sanicjwt2.config.access_token_name(), None
-    )
-    wrong_token_grab_2 = response2.json.get(
-        sanicjwt1.config.access_token_name(), None
-    )
+    wrong_token_grab_1 = response1.json.get(sanicjwt2.config.access_token_name(), None)
+    wrong_token_grab_2 = response2.json.get(sanicjwt1.config.access_token_name(), None)
 
     assert wrong_token_grab_1 is None
     assert wrong_token_grab_2 is None
 
     _, response1 = app.test_client.get(
-        "/test1/",
-        headers={"Authorization": "Bearer {}".format(access_token_1)},
+        "/test1/", headers={"Authorization": "Bearer {}".format(access_token_1)}
     )
     _, response2 = app.test_client.get(
-        "/",
-        cookies={sanicjwt2.config.cookie_access_token_name(): access_token_2},
+        "/", cookies={sanicjwt2.config.cookie_access_token_name(): access_token_2}
     )
 
     assert response1.status == 200
@@ -92,12 +82,10 @@ def test_protected_blueprints():
     assert response2.json.get("type") == "app"
 
     _, response1 = app.test_client.get(
-        "/test1/",
-        headers={"Authorization": "Bearer {}".format(access_token_2)},
+        "/test1/", headers={"Authorization": "Bearer {}".format(access_token_2)}
     )
     _, response2 = app.test_client.get(
-        "/",
-        cookies={sanicjwt2.config.cookie_access_token_name(): access_token_1},
+        "/", cookies={sanicjwt2.config.cookie_access_token_name(): access_token_1}
     )
 
     assert response1.status == 401
@@ -119,20 +107,14 @@ def test_protected_blueprints_debug():
         "/a", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token_1 = response1.json.get(
-        sanicjwt1.config.access_token_name(), None
-    )
-    access_token_2 = response2.json.get(
-        sanicjwt2.config.access_token_name(), None
-    )
+    access_token_1 = response1.json.get(sanicjwt1.config.access_token_name(), None)
+    access_token_2 = response2.json.get(sanicjwt2.config.access_token_name(), None)
 
     _, response1 = app.test_client.get(
-        "/test1/",
-        headers={"Authorization": "Bearer {}".format(access_token_2)},
+        "/test1/", headers={"Authorization": "Bearer {}".format(access_token_2)}
     )
     _, response2 = app.test_client.get(
-        "/",
-        cookies={sanicjwt2.config.cookie_access_token_name(): access_token_1},
+        "/", cookies={sanicjwt2.config.cookie_access_token_name(): access_token_1}
     )
 
     assert response1.status == 400

--- a/tests/test_endpoints_init_on_bp_decorated.py
+++ b/tests/test_endpoints_init_on_bp_decorated.py
@@ -60,8 +60,7 @@ def test_protected_blueprint():
     assert response.json.get("message") == "hello world"
 
     _, response = app.test_client.get(
-        "/test/user/1",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/test/user/1", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 401

--- a/tests/test_endpoints_init_on_bp_multiple.py
+++ b/tests/test_endpoints_init_on_bp_multiple.py
@@ -66,33 +66,23 @@ def test_protected_blueprints():
     assert response1.status == 200
     assert response2.status == 200
 
-    access_token_1 = response1.json.get(
-        sanicjwt1.config.access_token_name(), None
-    )
-    access_token_2 = response2.json.get(
-        sanicjwt2.config.access_token_name(), None
-    )
+    access_token_1 = response1.json.get(sanicjwt1.config.access_token_name(), None)
+    access_token_2 = response2.json.get(sanicjwt2.config.access_token_name(), None)
 
     assert access_token_1 is not None
     assert access_token_2 is not None
 
-    wrong_token_grab_1 = response1.json.get(
-        sanicjwt2.config.access_token_name(), None
-    )
-    wrong_token_grab_2 = response2.json.get(
-        sanicjwt1.config.access_token_name(), None
-    )
+    wrong_token_grab_1 = response1.json.get(sanicjwt2.config.access_token_name(), None)
+    wrong_token_grab_2 = response2.json.get(sanicjwt1.config.access_token_name(), None)
 
     assert wrong_token_grab_1 is None
     assert wrong_token_grab_2 is None
 
     _, response1 = app.test_client.get(
-        "/test1/",
-        headers={"Authorization": "Bearer {}".format(access_token_1)},
+        "/test1/", headers={"Authorization": "Bearer {}".format(access_token_1)}
     )
     _, response2 = app.test_client.get(
-        "/test2/",
-        cookies={sanicjwt2.config.cookie_access_token_name(): access_token_2},
+        "/test2/", cookies={sanicjwt2.config.cookie_access_token_name(): access_token_2}
     )
 
     assert response1.status == 200
@@ -101,12 +91,10 @@ def test_protected_blueprints():
     assert response2.json.get("version") == 2
 
     _, response1 = app.test_client.get(
-        "/test1/",
-        headers={"Authorization": "Bearer {}".format(access_token_2)},
+        "/test1/", headers={"Authorization": "Bearer {}".format(access_token_2)}
     )
     _, response2 = app.test_client.get(
-        "/test2/",
-        cookies={sanicjwt2.config.cookie_access_token_name(): access_token_1},
+        "/test2/", cookies={sanicjwt2.config.cookie_access_token_name(): access_token_1}
     )
 
     assert response1.status == 401
@@ -128,20 +116,14 @@ def test_protected_blueprints_debug():
         "/test2/a", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token_1 = response1.json.get(
-        sanicjwt1.config.access_token_name(), None
-    )
-    access_token_2 = response2.json.get(
-        sanicjwt2.config.access_token_name(), None
-    )
+    access_token_1 = response1.json.get(sanicjwt1.config.access_token_name(), None)
+    access_token_2 = response2.json.get(sanicjwt2.config.access_token_name(), None)
 
     _, response1 = app.test_client.get(
-        "/test1/",
-        headers={"Authorization": "Bearer {}".format(access_token_2)},
+        "/test1/", headers={"Authorization": "Bearer {}".format(access_token_2)}
     )
     _, response2 = app.test_client.get(
-        "/test2/",
-        cookies={sanicjwt2.config.cookie_access_token_name(): access_token_1},
+        "/test2/", cookies={sanicjwt2.config.cookie_access_token_name(): access_token_1}
     )
 
     assert response1.status == 400

--- a/tests/test_endpoints_init_on_bp_retrieve_user.py
+++ b/tests/test_endpoints_init_on_bp_retrieve_user.py
@@ -8,11 +8,7 @@ def app_with_retrieve_user_on_bp(
 ):
     app, bp = app_with_bp_setup_without_init
     sanicjwt = Initialize(
-        bp,
-        app=app,
-        authenticate=authenticate,
-        retrieve_user=retrieve_user,
-        debug=True,
+        bp, app=app, authenticate=authenticate, retrieve_user=retrieve_user, debug=True
     )
     app.blueprint(bp)
     return app, sanicjwt, bp

--- a/tests/test_endpoints_jwt_cryptography.py
+++ b/tests/test_endpoints_jwt_cryptography.py
@@ -61,8 +61,7 @@ def test_jwt_rsa_crypto_from_path_object(public_rsa_key, private_rsa_key):
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -96,8 +95,7 @@ def test_jwt_rsapss_crypto_from_path_object(public_rsa_key, private_rsa_key):
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -131,8 +129,7 @@ def test_jwt_ec_crypto_from_path_object(public_ec_key, private_ec_key):
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -167,17 +164,14 @@ def test_jwt_rsa_crypto_from_fullpath_as_str(public_rsa_key, private_rsa_key):
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
     assert response.json.get("protected") is True
 
 
-def test_jwt_rsapss_crypto_from_fullpath_as_str(
-    public_rsa_key, private_rsa_key
-):
+def test_jwt_rsapss_crypto_from_fullpath_as_str(public_rsa_key, private_rsa_key):
     app = Sanic()
 
     class MyConfig(Configuration):
@@ -206,8 +200,7 @@ def test_jwt_rsapss_crypto_from_fullpath_as_str(
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -242,8 +235,7 @@ def test_jwt_ec_crypto_from_fullpath_as_str(public_ec_key, private_ec_key):
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -277,8 +269,7 @@ def test_jwt_rsa_crypto_from_str(public_rsa_key, private_rsa_key):
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -312,8 +303,7 @@ def test_jwt_rsapss_crypto_from_str(public_rsa_key, private_rsa_key):
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -347,8 +337,7 @@ def test_jwt_ec_crypto_from_str(public_ec_key, private_ec_key):
     assert access_token is not None
 
     _, response = app.test_client.get(
-        "/protected/",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected/", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
@@ -405,10 +394,7 @@ def test_jwt_crypto_very_long_path():
 def test_jwt_crypto_missing_private_key(public_rsa_key):
     with pytest.raises(exceptions.RequiredKeysNotFound):
         Initialize(
-            Sanic(),
-            authenticate=lambda: True,
-            secret=public_rsa_key,
-            algorithm="RS256",
+            Sanic(), authenticate=lambda: True, secret=public_rsa_key, algorithm="RS256"
         )
 
 

--- a/tests/test_endpoints_multiple.py
+++ b/tests/test_endpoints_multiple.py
@@ -5,8 +5,7 @@ import pytest
 def access_tokens(app_with_bp):
     app, app_int, bp, bp_init = app_with_bp
     _, response1 = app.test_client.post(
-        app_int._get_url_prefix(),
-        json={"username": "user1", "password": "abcxyz"},
+        app_int._get_url_prefix(), json={"username": "user1", "password": "abcxyz"}
     )
     _, response2 = app.test_client.post(
         bp_init._get_url_prefix() + "/",

--- a/tests/test_endpoints_query_string.py
+++ b/tests/test_endpoints_query_string.py
@@ -66,7 +66,6 @@ def app_with_refresh_token(users, authenticate):
 
 
 class TestEndpointsQueryString(object):
-
     @pytest.yield_fixture
     def authenticated_response(self, app_with_refresh_token):
         sanic_app, sanicjwt = app_with_refresh_token
@@ -87,7 +86,9 @@ class TestEndpointsQueryString(object):
         assert access_token_from_json is not None
 
         payload_json = jwt.decode(
-            access_token_from_json, sanicjwt.config.secret()
+            access_token_from_json,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
         )
 
         assert access_token_from_json is not None
@@ -101,14 +102,17 @@ class TestEndpointsQueryString(object):
         access_token_from_json = authenticated_response.json.get(
             sanicjwt.config.access_token_name(), None
         )
-        payload = jwt.decode(access_token_from_json, sanicjwt.config.secret())
+        payload = jwt.decode(
+            access_token_from_json,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
+        )
 
         assert isinstance(payload, dict)
         assert sanicjwt.config.user_id() in payload
 
         me_url = "/auth/me?{}={}".format(
-            sanicjwt.config.query_string_access_token_name(),
-            access_token_from_json,
+            sanicjwt.config.query_string_access_token_name(), access_token_from_json
         )
         _, response = sanic_app.test_client.get(me_url)
 
@@ -116,9 +120,7 @@ class TestEndpointsQueryString(object):
         assert response.json.get("me") is not None
         assert sanicjwt.config.user_id() in response.json.get("me")
 
-        user_id_from_me = response.json.get("me").get(
-            sanicjwt.config.user_id()
-        )
+        user_id_from_me = response.json.get("me").get(sanicjwt.config.user_id())
         user_id_from_payload = payload.get(sanicjwt.config.user_id())
 
         assert response.status == 200
@@ -133,17 +135,18 @@ class TestEndpointsQueryString(object):
         access_token_from_json = authenticated_response.json.get(
             sanicjwt.config.access_token_name(), None
         )
-        payload = jwt.decode(access_token_from_json, sanicjwt.config.secret())
+        payload = jwt.decode(
+            access_token_from_json,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
+        )
 
         assert isinstance(payload, dict)
         assert sanicjwt.config.user_id() in payload
 
         url = "/auth/me"
         _, response = sanic_app.test_client.get(
-            url,
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_json)
-            },
+            url, headers={"Authorization": "Bearer {}".format(access_token_from_json)}
         )
 
         assert response.status == 401
@@ -153,8 +156,7 @@ class TestEndpointsQueryString(object):
         )
 
         url += "?{}={}".format(
-            sanicjwt.config.query_string_access_token_name(),
-            access_token_from_json,
+            sanicjwt.config.query_string_access_token_name(), access_token_from_json
         )
         _, response = sanic_app.test_client.get(url)
 
@@ -162,10 +164,7 @@ class TestEndpointsQueryString(object):
 
         url = "/protected"
         _, response = sanic_app.test_client.get(
-            url,
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_json)
-            },
+            url, headers={"Authorization": "Bearer {}".format(access_token_from_json)}
         )
 
         assert response.status == 401
@@ -176,10 +175,7 @@ class TestEndpointsQueryString(object):
 
         url = "/auth/verify"
         _, response = sanic_app.test_client.get(
-            url,
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_json)
-            },
+            url, headers={"Authorization": "Bearer {}".format(access_token_from_json)}
         )
 
         assert response.status == 401
@@ -189,8 +185,7 @@ class TestEndpointsQueryString(object):
         )
 
         url = "/auth/me?{}={}".format(
-            sanicjwt.config.query_string_access_token_name(),
-            access_token_from_json,
+            sanicjwt.config.query_string_access_token_name(), access_token_from_json
         )
         _, response = sanic_app.test_client.get(url)
 
@@ -198,8 +193,7 @@ class TestEndpointsQueryString(object):
         assert response.json.get("me")
 
         url = "/protected?{}={}".format(
-            sanicjwt.config.query_string_access_token_name(),
-            access_token_from_json,
+            sanicjwt.config.query_string_access_token_name(), access_token_from_json
         )
         _, response = sanic_app.test_client.get(url)
 
@@ -216,46 +210,41 @@ class TestEndpointsQueryString(object):
         access_token_from_json = authenticated_response.json.get(
             sanicjwt.config.access_token_name(), None
         )
-        payload = jwt.decode(access_token_from_json, sanicjwt.config.secret())
+        payload = jwt.decode(
+            access_token_from_json,
+            sanicjwt.config.secret(),
+            algorithms=sanicjwt.config.algorithm(),
+        )
 
         assert isinstance(payload, dict)
         assert sanicjwt.config.user_id() in payload
 
         _, response = sanic_app.test_client.get(
             "/auth/me",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_json)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_json)},
         )
 
         assert response.status == 200
         assert response.json.get("me") is not None
-        assert (
-            response.json.get("me").get(sanicjwt.config.user_id())
-            == payload.get(sanicjwt.config.user_id())
+        assert response.json.get("me").get(sanicjwt.config.user_id()) == payload.get(
+            sanicjwt.config.user_id()
         )
 
         _, response = sanic_app.test_client.get(
             "/protected",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_json)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_json)},
         )
 
         assert response.status == 200
 
         _, response = sanic_app.test_client.get(
             "/auth/verify",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_json)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_json)},
         )
 
         _, response = sanic_app.test_client.get(
             "/protected",
-            headers={
-                "Authorization": "Bearer {}".format(access_token_from_json)
-            },
+            headers={"Authorization": "Bearer {}".format(access_token_from_json)},
         )
 
         assert response.status == 200
@@ -287,14 +276,13 @@ class TestEndpointsQueryString(object):
         assert response.status == 200
         assert response.json is not None
 
-        new_access_token = response.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        new_access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
         assert new_access_token is not None
-        assert response.json.get(
-            sanicjwt.config.query_string_refresh_token_name(), None
-        ) is None  # there is no new refresh token
+        assert (
+            response.json.get(sanicjwt.config.query_string_refresh_token_name(), None)
+            is None
+        )  # there is no new refresh token
         assert sanicjwt.config.query_string_refresh_token_name() not in response.json
 
         url = "/auth/refresh?{}={}&{}={}".format(
@@ -330,18 +318,17 @@ class TestEndpointsQueryString(object):
         _, response = sanic_app.test_client.post(url)
 
         assert response.status == 200
-        assert response.json.get(
-            sanicjwt.config.query_string_refresh_token_name(), None
-        ) is None  # there is no new refresh token
+        assert (
+            response.json.get(sanicjwt.config.query_string_refresh_token_name(), None)
+            is None
+        )  # there is no new refresh token
         assert sanicjwt.config.query_string_refresh_token_name() not in response.json
 
     def test_auth_verify_invalid_token(self, app_with_refresh_token):
         sanic_app, sanicjwt = app_with_refresh_token
 
         _, response = sanic_app.test_client.get(
-            "/auth/verify?{}=".format(
-                sanicjwt.config.cookie_access_token_name()
-            )
+            "/auth/verify?{}=".format(sanicjwt.config.cookie_access_token_name())
         )
         assert response.status == 401
         assert response.json.get("exception") == "MissingAuthorizationQueryArg"

--- a/tests/test_endpoints_scoped.py
+++ b/tests/test_endpoints_scoped.py
@@ -7,7 +7,6 @@ from sanic_jwt.decorators import protected, scoped
 
 
 class User:
-
     def __init__(self, id, username, password, scopes):
         self.id = id
         self.username = username
@@ -15,11 +14,7 @@ class User:
         self.scopes = scopes
 
     def to_dict(self):
-        return {
-            "user_id": self.id,
-            "username": self.username,
-            "scopes": self.scopes,
-        }
+        return {"user_id": self.id, "username": self.username, "scopes": self.scopes}
 
     @property
     def user_id(self):
@@ -188,7 +183,6 @@ def app_with_scopes_destructure(app_with_scopes_base):
 
 
 class TestEndpointsSync(object):
-
     @pytest.yield_fixture
     def user1(self, app_with_scopes):
         sanic_app, _ = app_with_scopes
@@ -252,114 +246,83 @@ class TestEndpointsSync(object):
         _, response = sanic_app.test_client.get("/auth/me")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/1")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/2")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/3")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/4")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/5")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/6/1")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/6/foo")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/7/1")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/7/foo")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/8")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/9/1")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
         _, response = sanic_app.test_client.get("/protected/scoped/9/foo")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")
 
     def test_scopes_user1(self, app_with_scopes, user1):
         sanic_app, sanicjwt = app_with_scopes
-        access_token = user1.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        access_token = user1.json.get(sanicjwt.config.access_token_name(), None)
 
         _, response = sanic_app.test_client.get("/")
         assert response.status == 200
         assert response.json.get("hello") == "world"
 
         _, response = sanic_app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -368,8 +331,7 @@ class TestEndpointsSync(object):
         assert response.json.get("me").get("scopes") == ["user"]
 
         _, response = sanic_app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -470,17 +432,14 @@ class TestEndpointsSync(object):
 
     def test_scopes_user2(self, app_with_scopes, user2):
         sanic_app, sanicjwt = app_with_scopes
-        access_token = user2.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        access_token = user2.json.get(sanicjwt.config.access_token_name(), None)
 
         _, response = sanic_app.test_client.get("/")
         assert response.status == 200
         assert response.json.get("hello") == "world"
 
         _, response = sanic_app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -489,8 +448,7 @@ class TestEndpointsSync(object):
         assert response.json.get("me").get("scopes") == ["user", "admin"]
 
         _, response = sanic_app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -589,17 +547,14 @@ class TestEndpointsSync(object):
 
     def test_scopes_user3(self, app_with_scopes, user3):
         sanic_app, sanicjwt = app_with_scopes
-        access_token = user3.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        access_token = user3.json.get(sanicjwt.config.access_token_name(), None)
 
         _, response = sanic_app.test_client.get("/")
         assert response.status == 200
         assert response.json.get("hello") == "world"
 
         _, response = sanic_app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -608,8 +563,7 @@ class TestEndpointsSync(object):
         assert response.json.get("me").get("scopes") == ["user:read"]
 
         _, response = sanic_app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -707,17 +661,14 @@ class TestEndpointsSync(object):
 
     def test_scopes_user4(self, app_with_scopes, user4):
         sanic_app, sanicjwt = app_with_scopes
-        access_token = user4.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        access_token = user4.json.get(sanicjwt.config.access_token_name(), None)
 
         _, response = sanic_app.test_client.get("/")
         assert response.status == 200
         assert response.json.get("hello") == "world"
 
         _, response = sanic_app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -726,8 +677,7 @@ class TestEndpointsSync(object):
         assert response.json.get("me").get("scopes") == ["client1"]
 
         _, response = sanic_app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -846,17 +796,14 @@ class TestEndpointsSync(object):
 
     def test_scopes_user5(self, app_with_scopes, user5):
         sanic_app, sanicjwt = app_with_scopes
-        access_token = user5.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        access_token = user5.json.get(sanicjwt.config.access_token_name(), None)
 
         _, response = sanic_app.test_client.get("/")
         assert response.status == 200
         assert response.json.get("hello") == "world"
 
         _, response = sanic_app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -865,8 +812,7 @@ class TestEndpointsSync(object):
         assert response.json.get("me").get("scopes") == ["admin"]
 
         _, response = sanic_app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -965,17 +911,14 @@ class TestEndpointsSync(object):
 
     def test_scopes_user6(self, app_with_scopes, user6):
         sanic_app, sanicjwt = app_with_scopes
-        access_token = user6.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        access_token = user6.json.get(sanicjwt.config.access_token_name(), None)
 
         _, response = sanic_app.test_client.get("/")
         assert response.status == 200
         assert response.json.get("hello") == "world"
 
         _, response = sanic_app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -984,8 +927,7 @@ class TestEndpointsSync(object):
         assert response.json.get("me").get("scopes") is None
 
         _, response = sanic_app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200

--- a/tests/test_endpoints_scoped_simple.py
+++ b/tests/test_endpoints_scoped_simple.py
@@ -16,11 +16,8 @@ async def scoped(request):
 
 
 class TestEndpointsScoped(object):
-
     def test_scoped_empty(self):
         _, response = app.test_client.get("/scoped_empty")
         assert response.status == 401
         assert response.json.get("exception") == "Unauthorized"
-        assert "Authorization header not present." in response.json.get(
-            "reasons"
-        )
+        assert "Authorization header not present." in response.json.get("reasons")

--- a/tests/test_endpoints_sync_methods.py
+++ b/tests/test_endpoints_sync_methods.py
@@ -27,9 +27,7 @@ def app_with_sync_methods(users):
         password = request.json.get("password", None)
 
         if not username or not password:
-            raise exceptions.AuthenticationFailed(
-                "Missing username or password."
-            )
+            raise exceptions.AuthenticationFailed("Missing username or password.")
 
         user = None
 
@@ -76,9 +74,7 @@ def app_with_sync_methods(users):
     )
 
     sanic_app.config.SANIC_JWT_REFRESH_TOKEN_ENABLED = True
-    sanic_app.config.SANIC_JWT_SECRET = str(
-        binascii.hexlify(os.urandom(32)), "utf-8"
-    )
+    sanic_app.config.SANIC_JWT_SECRET = str(binascii.hexlify(os.urandom(32)), "utf-8")
 
     @sanic_app.route("/")
     async def helloworld(request):
@@ -93,7 +89,6 @@ def app_with_sync_methods(users):
 
 
 class TestEndpointsSync(object):
-
     @pytest.yield_fixture
     def authenticated_response(self, app_with_sync_methods):
         sanic_app, _ = app_with_sync_methods
@@ -109,17 +104,14 @@ class TestEndpointsSync(object):
         assert response.status == 200
         assert response.json.get("hello") == "world"
 
-    def test_protected_endpoint(
-        self, app_with_sync_methods, authenticated_response
-    ):
+    def test_protected_endpoint(self, app_with_sync_methods, authenticated_response):
         sanic_app, sanicjwt = app_with_sync_methods
         access_token = authenticated_response.json.get(
             sanicjwt.config.access_token_name(), None
         )
 
         _, response = sanic_app.test_client.get(
-            "/protected",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -132,8 +124,7 @@ class TestEndpointsSync(object):
         )
 
         _, response = sanic_app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 200
@@ -156,9 +147,7 @@ class TestEndpointsSync(object):
             assert response.json.get("exception") == "InvalidToken"
             assert "Signature has expired." in response.json.get("reasons")
 
-    def test_refresh_token_sync(
-        self, app_with_sync_methods, authenticated_response
-    ):
+    def test_refresh_token_sync(self, app_with_sync_methods, authenticated_response):
         sanic_app, sanicjwt = app_with_sync_methods
         access_token = authenticated_response.json.get(
             sanicjwt.config.access_token_name(), None
@@ -173,13 +162,11 @@ class TestEndpointsSync(object):
             json={sanicjwt.config.refresh_token_name(): refresh_token},
         )
 
-        new_access_token = response.json.get(
-            sanicjwt.config.access_token_name(), None
-        )
+        new_access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
         assert response.status == 200
         assert new_access_token is not None
-        assert response.json.get(
-            sanicjwt.config.refresh_token_name(), None
-        ) is None  # there is no new refresh token
+        assert (
+            response.json.get(sanicjwt.config.refresh_token_name(), None) is None
+        )  # there is no new refresh token
         assert sanicjwt.config.refresh_token_name() not in response.json

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,9 +14,7 @@ def test_abort_called_in_endpoint(app):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     _, response = sanic_app.test_client.get(
         "/abort", headers={"Authorization": "Bearer {}".format(access_token)}

--- a/tests/test_extend_payload.py
+++ b/tests/test_extend_payload.py
@@ -8,7 +8,6 @@ import jwt
 
 
 class User:
-
     def __init__(self, id, username, password):
         self.user_id = id
         self.username = username
@@ -45,15 +44,12 @@ async def authenticate(request, *args, **kwargs):
 
 
 def test_extend_simple():
-
     def my_extender(payload):
         payload.update({"foo": "bar"})
         return payload
 
     app = Sanic()
-    sanicjwt = Initialize(
-        app, authenticate=authenticate, extend_payload=my_extender
-    )
+    sanicjwt = Initialize(app, authenticate=authenticate, extend_payload=my_extender)
 
     _, response = app.test_client.post(
         "/auth", json={"username": "user1", "password": "abcxyz"}
@@ -61,23 +57,22 @@ def test_extend_simple():
     assert response.status == 200
 
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
-    payload = jwt.decode(access_token, sanicjwt.config.secret())
+    payload = jwt.decode(
+        access_token, sanicjwt.config.secret(), algorithms=sanicjwt.config.algorithm()
+    )
 
     assert "foo" in payload
     assert payload.get("foo") == "bar"
 
 
 def test_extend_with_username():
-
     def my_extender(payload, user):
         username = user.to_dict().get("username")
         payload.update({"username": username})
         return payload
 
     app = Sanic()
-    sanicjwt = Initialize(
-        app, authenticate=authenticate, extend_payload=my_extender
-    )
+    sanicjwt = Initialize(app, authenticate=authenticate, extend_payload=my_extender)
 
     _, response = app.test_client.post(
         "/auth", json={"username": "user1", "password": "abcxyz"}
@@ -85,16 +80,16 @@ def test_extend_with_username():
     assert response.status == 200
 
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
-    payload = jwt.decode(access_token, sanicjwt.config.secret())
+    payload = jwt.decode(
+        access_token, sanicjwt.config.secret(), algorithms=sanicjwt.config.algorithm()
+    )
 
     assert "username" in payload
     assert payload.get("username") == "user1"
 
 
 def test_extend_with_username_as_subclass():
-
     class MyAuthentication(Authentication):
-
         async def extend_payload(self, payload, user):
             username = user.to_dict().get("username")
             payload.update({"username": username})
@@ -111,14 +106,15 @@ def test_extend_with_username_as_subclass():
     assert response.status == 200
 
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
-    payload = jwt.decode(access_token, sanicjwt.config.secret())
+    payload = jwt.decode(
+        access_token, sanicjwt.config.secret(), algorithms=sanicjwt.config.algorithm()
+    )
 
     assert "username" in payload
     assert payload.get("username") == "user1"
 
 
 def test_extend_with_mising_claim():
-
     def my_extender(payload, user):
         del payload["nbf"]
         return payload

--- a/tests/test_extra_verifications.py
+++ b/tests/test_extra_verifications.py
@@ -10,12 +10,9 @@ def test_extra_verification_passing(app_with_extra_verification):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 401
@@ -25,19 +22,15 @@ def test_extra_verification_passing(app_with_extra_verification):
         "/auth", json={"username": "user2", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200
 
 
 def test_extra_verification_non_boolean_return(authenticate):
-
     def bad_return(payload):
         return 123
 
@@ -60,13 +53,10 @@ def test_extra_verification_non_boolean_return(authenticate):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 500
@@ -94,13 +84,10 @@ def test_extra_verification_non_callable(authenticate):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
 
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 500

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -23,9 +23,7 @@ def test_store_refresh_token_ommitted():
     app.config.SANIC_JWT_REFRESH_TOKEN_ENABLED = True
 
     with pytest.raises(exceptions.RefreshTokenNotImplemented):
-        Initialize(
-            app, authenticate=lambda: True, retrieve_refresh_token=lambda: True
-        )
+        Initialize(app, authenticate=lambda: True, retrieve_refresh_token=lambda: True)
 
 
 def test_retrieve_refresh_token_ommitted():
@@ -33,9 +31,7 @@ def test_retrieve_refresh_token_ommitted():
     app.config.SANIC_JWT_REFRESH_TOKEN_ENABLED = True
 
     with pytest.raises(exceptions.RefreshTokenNotImplemented):
-        initialize(
-            app, authenticate=lambda: True, store_refresh_token=lambda: True
-        )
+        initialize(app, authenticate=lambda: True, store_refresh_token=lambda: True)
 
 
 def test_store_refresh_token_and_retrieve_refresh_token_defined():
@@ -59,9 +55,7 @@ def test_invalid_classview():
         pass
 
     with pytest.raises(exceptions.InvalidClassViewsFormat):
-        initialize(
-            app, authenticate=lambda: True, class_views=[(object, NotAView)]
-        )
+        initialize(app, authenticate=lambda: True, class_views=[(object, NotAView)])
 
 
 def test_initialize_class_missing_authenticate():
@@ -160,9 +154,7 @@ def test_initialize_class_on_blueprint_with_url_prefix_and_config():
 
 
 def test_initialize_with_custom_endpoint_not_subclassed():
-
     class SubclassHTTPMethodView(HTTPMethodView):
-
         async def options(self, request):
             return text("", status=204)
 
@@ -179,7 +171,6 @@ def test_initialize_with_custom_endpoint_not_subclassed():
 
 
 def test_invalid_configuration_object():
-
     class MyInvalidConfiguration:
         MY_CUSTOM_SETTING = "foo"
 
@@ -189,9 +180,7 @@ def test_invalid_configuration_object():
 
 
 def test_invalid_authentication_object():
-
     class MyInvalidAuthentication:
-
         async def authenticate(*args, **kwargs):
             return True
 
@@ -201,7 +190,6 @@ def test_invalid_authentication_object():
 
 
 def test_invalid_response_object():
-
     class MyInvalidResponses:
         pass
 

--- a/tests/test_me_invalid.py
+++ b/tests/test_me_invalid.py
@@ -37,10 +37,10 @@ def test_expired(app_with_retrieve_user):
     async def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+    payload = jwt.decode(
+        access_token, sanic_jwt.config.secret(), algorithms=sanic_jwt.config.algorithm()
     )
-    payload = jwt.decode(access_token, sanic_jwt.config.secret())
     exp = payload.get("exp", None)
 
     assert "exp" in payload
@@ -52,8 +52,7 @@ def test_expired(app_with_retrieve_user):
         assert datetime.utcnow() > exp
 
         _, response = sanic_app.test_client.get(
-            "/auth/me",
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
         )
 
         assert response.status == 401

--- a/tests/test_microservices.py
+++ b/tests/test_microservices.py
@@ -43,15 +43,12 @@ def test_microservice_interaction():
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(
-        sanic_jwt.config.access_token_name(), None
-    )
+    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
     assert response.status == 200
     assert access_token is not None
 
     _, response = microservice_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     assert response.status == 200

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,6 @@ def fcontent():
 
 @pytest.mark.asyncio
 async def test_call():
-
     def sync_func(a, b, c=0):
         return a + b + c
 

--- a/tests/test_wrong_token.py
+++ b/tests/test_wrong_token.py
@@ -7,16 +7,11 @@ def test_wrong_token(app):
     payload = {"foo": "bar"}
 
     access_token = jwt.encode(
-        payload,
-        sanic_jwt.config.secret(),
-        algorithm=sanic_jwt.config.algorithm(),
-    ).decode(
-        "utf-8"
-    )
+        payload, sanic_jwt.config.secret(), algorithm=sanic_jwt.config.algorithm()
+    ).decode("utf-8")
 
     _, response = sanic_app.test_client.get(
-        "/protected",
-        headers={"Authorization": "Bearer {}".format(access_token)},
+        "/protected", headers={"Authorization": "Bearer {}".format(access_token)}
     )
 
     print(response.json)


### PR DESCRIPTION
## Goal
address issue 137: remove test warnings.

## Approach
add _algorithms_ parameter when calling decode() function directly from tests.

## New Features/Changes
additionally, run _black_ on all tests

## Example
    payload = jwt.decode(
        access_token, sanicjwt.config.secret(), **algorithms=sanicjwt.config.algorithm()**
    )

