### PR TITLE
Issue 40

### DIFF
--- a/sanic_jwt/configuration.py
+++ b/sanic_jwt/configuration.py
@@ -50,7 +50,8 @@ defaults = {
     "url_prefix": "/auth",
     "user_id": "user_id",
     "blueprint_name": "auth_bp",
-    "verify_exp": True
+    "verify_exp": True,
+    "login_redirect_url": None,
 }
 
 aliases = {

--- a/sanic_jwt/configuration.py
+++ b/sanic_jwt/configuration.py
@@ -55,7 +55,8 @@ defaults = {
 }
 
 aliases = {
-    "cookie_access_token_name": "cookie_token_name", "secret": "public_key"
+    "cookie_access_token_name": "cookie_token_name",
+    "secret": "public_key",
 }
 
 ignore_keys = (
@@ -96,7 +97,6 @@ def _update_config_item(key, item_aliases, instance):
 
 
 class ConfigItem:
-
     def __init__(
         self,
         value,
@@ -151,7 +151,6 @@ class ConfigItem:
 
 
 class Configuration:
-
     def __iter__(self):  # noqa
         for key in self.config_keys:
             yield getattr(self, key)
@@ -182,9 +181,8 @@ class Configuration:
 
             # check if a configuration key is set
             # and is an instance of ConfigItem
-            if (
-                hasattr(instance, key)
-                and isinstance(getattr(instance, key), ConfigItem)
+            if hasattr(instance, key) and isinstance(
+                getattr(instance, key), ConfigItem
             ):
                 _update_config_item(key, item_aliases, instance)
             # check if a configuration key is set with a value
@@ -286,9 +284,8 @@ class Configuration:
 
     def _validate_secret(self):
         logger.debug("validating provided secret")
-        if (
-            self.secret() is None
-            or (isinstance(self.secret(), str) and self.secret().strip() == "")
+        if self.secret() is None or (
+            isinstance(self.secret(), str) and self.secret().strip() == ""
         ):
             raise exceptions.InvalidConfiguration(
                 "the SANIC_JWT_SECRET parameter cannot be None nor an empty "
@@ -297,14 +294,11 @@ class Configuration:
 
     def _validate_keys(self):
         logger.debug("validating keys (if needed)")
-        if (
-            utils.algorithm_is_asymmetric(self.algorithm())
-            and (
-                self.private_key() is None
-                or (
-                    isinstance(self.private_key(), str)
-                    and self.private_key().strip() == ""
-                )
+        if utils.algorithm_is_asymmetric(self.algorithm()) and (
+            self.private_key() is None
+            or (
+                isinstance(self.private_key(), str)
+                and self.private_key().strip() == ""
             )
         ):
             raise exceptions.RequiredKeysNotFound

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -34,14 +34,16 @@ def test_forgotten_initialized_on_protected():
     access_token = response.json.get(sanicjwt.config.access_token_name(), None)
 
     _, response = app.test_client.get(
-        "/test/protected", headers={"Authorization": "Bearer {}".format(access_token)}
+        "/test/protected",
+        headers={"Authorization": "Bearer {}".format(access_token)},
     )
 
     assert response.status == 500
     assert response.json.get("exception") == "SanicJWTException"
 
     _, response = app.test_client.get(
-        "/test/scoped", headers={"Authorization": "Bearer {}".format(access_token)}
+        "/test/scoped",
+        headers={"Authorization": "Bearer {}".format(access_token)},
     )
 
     assert response.status == 500
@@ -73,7 +75,9 @@ def test_inject_user_regular(app_with_retrieve_user):
     async def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+    access_token = response.json.get(
+        sanic_jwt.config.access_token_name(), None
+    )
 
     _, response = sanic_app.test_client.get(
         "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
@@ -82,7 +86,8 @@ def test_inject_user_regular(app_with_retrieve_user):
     assert response.json.get("me").get("user_id") == 1
 
     _, response = sanic_app.test_client.get(
-        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
+        "/protected/user",
+        headers={"Authorization": "Bearer {}".format(access_token)},
     )
     assert response.status == 200
     assert response.json.get("user_id") == 1
@@ -100,7 +105,9 @@ def test_inject_user_on_instance(app_with_retrieve_user):
     async def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+    access_token = response.json.get(
+        sanic_jwt.config.access_token_name(), None
+    )
 
     _, response = sanic_app.test_client.get(
         "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
@@ -109,7 +116,8 @@ def test_inject_user_on_instance(app_with_retrieve_user):
     assert response.json.get("me").get("user_id") == 1
 
     _, response = sanic_app.test_client.get(
-        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
+        "/protected/user",
+        headers={"Authorization": "Bearer {}".format(access_token)},
     )
     assert response.status == 200
     assert response.json.get("user_id") == 1
@@ -127,7 +135,9 @@ def test_inject_user_on_instance_bp(app_with_retrieve_user):
     async def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+    access_token = response.json.get(
+        sanic_jwt.config.access_token_name(), None
+    )
 
     _, response = sanic_app.test_client.get(
         "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
@@ -136,7 +146,8 @@ def test_inject_user_on_instance_bp(app_with_retrieve_user):
     assert response.json.get("me").get("user_id") == 1
 
     _, response = sanic_app.test_client.get(
-        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
+        "/protected/user",
+        headers={"Authorization": "Bearer {}".format(access_token)},
     )
     assert response.status == 200
     assert response.json.get("user_id") == 1
@@ -154,7 +165,9 @@ def test_inject_user_on_instance_non_async(app_with_retrieve_user):
     def my_protected_user(request, user):
         return json({"user_id": user.user_id})
 
-    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+    access_token = response.json.get(
+        sanic_jwt.config.access_token_name(), None
+    )
 
     _, response = sanic_app.test_client.get(
         "/auth/me", headers={"Authorization": "Bearer {}".format(access_token)}
@@ -163,7 +176,8 @@ def test_inject_user_on_instance_non_async(app_with_retrieve_user):
     assert response.json.get("me").get("user_id") == 1
 
     _, response = sanic_app.test_client.get(
-        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
+        "/protected/user",
+        headers={"Authorization": "Bearer {}".format(access_token)},
     )
     assert response.status == 200
     assert response.json.get("user_id") == 1
@@ -189,10 +203,13 @@ def test_inject_user_with_auth_mode_off(app_with_retrieve_user):
         "/auth", json={"username": "user1", "password": "abcxyz"}
     )
 
-    access_token = response.json.get(sanic_jwt.config.access_token_name(), None)
+    access_token = response.json.get(
+        sanic_jwt.config.access_token_name(), None
+    )
 
     _, response = microservice_app.test_client.get(
-        "/protected/user", headers={"Authorization": "Bearer {}".format(access_token)}
+        "/protected/user",
+        headers={"Authorization": "Bearer {}".format(access_token)},
     )
 
     assert response.status == 200
@@ -201,3 +218,81 @@ def test_inject_user_with_auth_mode_off(app_with_retrieve_user):
     _, response = microservice_app.test_client.get("/protected/user")
 
     assert response.status == 401
+
+
+def test_redirect_without_url(app):
+    sanic_app, sanic_jwt = app
+
+    @sanic_app.route("/protected/static")
+    @sanic_jwt.protected(redirect_on_fail=True)
+    async def my_protected_static(request):
+        return text("", status=200)
+
+    _, response = sanic_app.test_client.get("/protected/static")
+
+    assert response.status == 401
+
+
+def test_redirect_with_decorator_url(app):
+    sanic_app, sanic_jwt = app
+
+    @sanic_app.route("/protected/static")
+    @sanic_jwt.protected(redirect_on_fail=True, redirect_url="/unprotected")
+    async def my_protected_static(request):
+        return text("", status=200)
+
+    @sanic_app.route("/unprotected")
+    async def my_unprotected_goto(request):
+        return text("unprotected content", status=200)
+
+    _, response = sanic_app.test_client.get("/protected/static")
+
+    assert response.status == 200 and response.text == "unprotected content"
+
+
+def test_redirect_with_configured_url():
+    sanic_app = Sanic()
+    sanic_jwt = Initialize(
+        sanic_app, auth_mode=False, login_redirect_url="/unprotected"
+    )
+
+    @sanic_app.route("/protected/static")
+    @sanic_jwt.protected(redirect_on_fail=True)
+    async def my_protected_static(request):
+        return text("", status=200)
+
+    @sanic_app.route("/unprotected")
+    async def my_unprotected_goto(request):
+        return text("unprotected content", status=200)
+
+    _, response = sanic_app.test_client.get("/protected/static")
+
+    assert response.status == 200 and response.text == "unprotected content"
+
+
+def test_authenticated_redirect(app_with_retrieve_user):
+    sanic_app, sanic_jwt = app_with_retrieve_user
+    _, response = sanic_app.test_client.post(
+        "/auth", json={"username": "user1", "password": "abcxyz"}
+    )
+
+    @sanic_app.route("/protected/static")
+    @sanic_jwt.protected(redirect_on_fail=True)
+    async def my_protected_static(request):
+        return text("protected content", status=200)
+
+    @sanic_app.route("/unprotected")
+    async def my_unprotected_goto(request):
+        return text("unprotected content", status=200)
+
+    access_token = response.json.get(
+        sanic_jwt.config.access_token_name(), None
+    )
+
+    _, response = sanic_app.test_client.get(
+        "/protected/static",
+        headers={"Authorization": "Bearer {}".format(access_token)},
+    )
+
+    assert response.status == 200 and response.text == "protected content"
+


### PR DESCRIPTION
## Goal
Issue-40: protecting static content

## Approach
extend the "protected" decorator to accept a _redirect_on_fail_ parameter, with target URL (default target URL may also be specified in the configuration) 

## New Features/Changes
1. Added login_redirect_url to configuration (default to None)
2. Extended the protected decorator to accept _redirect_on_fail_ (boolean) and potential _redirect_url_ (may override the configuration default, if exists) 
3. add unit tests for the added flows
4. black the touched files. 

## Example
added unit tests in _test_decorators.py_ which may serve as an example(s)

