### PR TITLE
Fix typo in Responses.get_token_response

### DIFF
--- a/docs/source/pages/endpoints.rst
+++ b/docs/source/pages/endpoints.rst
@@ -228,7 +228,7 @@ What if we wanted a ``/register`` endpoint? It could easily be added like this:
                 self.config.refresh_token_name(): refresh_token
             })
 
-            response = self.responses.get_token_reponse(
+            response = self.responses.get_token_response(
                 request,
                 access_token,
                 output,

--- a/example/custom_endpoint.py
+++ b/example/custom_endpoint.py
@@ -31,7 +31,7 @@ class Register(BaseEndpoint):
         )
         output.update({self.config.refresh_token_name: refresh_token})
 
-        response = self.responses.get_token_reponse(
+        response = self.responses.get_token_response(
             request,
             access_token,
             output,

--- a/sanic_jwt/endpoints.py
+++ b/sanic_jwt/endpoints.py
@@ -56,7 +56,7 @@ class AuthenticateEndpoint(BaseEndpoint):
 
         output = await self.do_output(output)
 
-        resp = self.responses.get_token_reponse(
+        resp = self.responses.get_token_response(
             request,
             access_token,
             output,
@@ -190,7 +190,7 @@ class RefreshEndpoint(BaseEndpoint):
         )
         output = await self.do_output(output)
 
-        resp = self.responses.get_token_reponse(
+        resp = self.responses.get_token_response(
             request, access_token, output, config=self.config
         )
 

--- a/sanic_jwt/responses.py
+++ b/sanic_jwt/responses.py
@@ -13,7 +13,7 @@ class Responses(BaseDerivative):
         return access_token, output
 
     @staticmethod
-    def get_token_reponse(
+    def get_token_response(
         request, access_token, output, config, refresh_token=None
     ):
         response = json(output)


### PR DESCRIPTION
## Goal
Typo in Responses.get_token_response

## Approach
Add 's' in 'get_token_response'

There already similar PR but it not finished