### PR TITLE
Resolve bug 190

### DIFF
--- a/sanic_jwt/endpoints.py
+++ b/sanic_jwt/endpoints.py
@@ -140,8 +140,6 @@ class VerifyEndpoint(BaseEndpoint):
 
 
 class RefreshEndpoint(BaseEndpoint):
-    decorators = [protected(verify_exp=False)]
-
     async def post(self, request, *args, **kwargs):
         request, args, kwargs = await self.do_incoming(request, args, kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def retrieve_user(userid_table):
 @pytest.yield_fixture
 def app(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(sanic_app, authenticate=authenticate)
 
     @sanic_app.route("/")
@@ -104,7 +104,7 @@ def app(username_table, authenticate):
 @pytest.yield_fixture
 def app_with_refresh_token(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app,
         authenticate=authenticate,
@@ -119,7 +119,7 @@ def app_with_refresh_token(username_table, authenticate):
 @pytest.yield_fixture
 def app_with_url_prefix(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, authenticate=authenticate, url_prefix="/somethingelse"
     )
@@ -138,7 +138,7 @@ def app_with_url_prefix(username_table, authenticate):
 
 @pytest.yield_fixture
 def app_with_bp_setup_without_init(username_table, authenticate):
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
 
     @sanic_app.route("/")
     async def helloworld(request):
@@ -178,7 +178,7 @@ def app_with_bp(app_with_bp_setup_without_init):
 @pytest.yield_fixture
 def app_with_extended_exp(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, authenticate=authenticate, expiration_delta=(60 * 60)
     )
@@ -198,7 +198,7 @@ def app_with_extended_exp(username_table, authenticate):
 @pytest.yield_fixture
 def app_with_leeway(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, authenticate=authenticate, leeway=(60 * 5)
     )
@@ -218,7 +218,7 @@ def app_with_leeway(username_table, authenticate):
 @pytest.yield_fixture
 def app_with_nbf(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app,
         authenticate=authenticate,
@@ -241,7 +241,7 @@ def app_with_nbf(username_table, authenticate):
 @pytest.yield_fixture
 def app_with_iat(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, authenticate=authenticate, claim_iat=True
     )
@@ -261,7 +261,7 @@ def app_with_iat(username_table, authenticate):
 @pytest.yield_fixture
 def app_with_iss(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, authenticate=authenticate, claim_iss="issuingserver"
     )
@@ -281,7 +281,7 @@ def app_with_iss(username_table, authenticate):
 @pytest.yield_fixture
 def app_with_aud(username_table, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, authenticate=authenticate, claim_aud="clientserver"
     )
@@ -301,7 +301,7 @@ def app_with_aud(username_table, authenticate):
 @pytest.yield_fixture
 def app_with_retrieve_user(retrieve_user, authenticate):
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, authenticate=authenticate, retrieve_user=retrieve_user
     )
@@ -325,7 +325,7 @@ def app_with_extra_verification(authenticate):
 
     extra_verifications = [user2]
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app,
         authenticate=authenticate,
@@ -353,7 +353,7 @@ def app_with_custom_claims(authenticate):
 
     custom_claims = [User2Claim]
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, authenticate=authenticate, custom_claims=custom_claims
     )

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -31,7 +31,7 @@ async def authenticate(request, *args, **kwargs):
 
 def test_authentication_subclass_without_authenticate_parameter():
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     with pytest.raises(exceptions.AuthenticateNotImplemented):
 
@@ -40,7 +40,7 @@ def test_authentication_subclass_without_authenticate_parameter():
 
 def test_authentication_subclass_with_autenticate_not_as_method():
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     with pytest.raises(exceptions.AuthenticateNotImplemented):
 
@@ -49,7 +49,7 @@ def test_authentication_subclass_with_autenticate_not_as_method():
 
 def test_authentication_subbclass_with_method_in_class():
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(app, authentication_class=AuthenticationInClassBody)
 
@@ -63,7 +63,7 @@ def test_authentication_subbclass_with_method_in_class():
 
 def test_payload_without_correct_key():
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     Initialize(
         app,
@@ -81,7 +81,7 @@ def test_payload_without_correct_key():
 
 def test_payload_not_a_dict():
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     Initialize(
         app,

--- a/tests/test_authentication_custom.py
+++ b/tests/test_authentication_custom.py
@@ -22,7 +22,7 @@ def app1():
         def extract_payload(self, request, verify=True, *args, **kwargs):
             return
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     Initialize(
         app, authentication_class=MyAuthentication, refresh_token_enabled=True
     )
@@ -48,7 +48,7 @@ def app2():
         def extract_payload(self, request, verify=True, *args, **kwargs):
             return {}
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     Initialize(
         app, authentication_class=MyAuthentication, refresh_token_enabled=True
     )

--- a/tests/test_complete_authentication.py
+++ b/tests/test_complete_authentication.py
@@ -72,7 +72,7 @@ def my_authentication_class(users, cache):
 
 @pytest.yield_fixture
 def sanic_app(users, my_authentication_class, cache):
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
 
     @sanic_app.route("/")
     async def helloworld(request):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -8,7 +8,7 @@ from sanic_jwt.configuration import ConfigItem
 
 def test_configuration_initialize_method_default():
     try:
-        app = Sanic()
+        app = Sanic("sanic-jwt-test")
         initialize(app, authenticate=lambda: True)
     except Exception as e:
         pytest.fail("Raised exception: {}".format(e))
@@ -16,14 +16,14 @@ def test_configuration_initialize_method_default():
 
 def test_configuration_initialize_class_default():
     try:
-        app = Sanic()
+        app = Sanic("sanic-jwt-test")
         Initialize(app, authenticate=lambda: True)
     except Exception as e:
         pytest.fail("Raised exception: {}".format(e))
 
 
 def test_configuration_initialize_class_app_level():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_ACCESS_TOKEN_NAME = "app-level"
     sanicjwt = Initialize(app, authenticate=lambda: True)
 
@@ -32,7 +32,7 @@ def test_configuration_initialize_class_app_level():
 
 
 def test_configuration_initialize_class_config_level_custom_classes():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_ACCESS_TOKEN_NAME = "app-level"
 
     class MyConfig(Configuration):
@@ -47,7 +47,7 @@ def test_configuration_initialize_class_config_level_custom_classes():
 
 
 def test_configuration_initialize_class_instance_level():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_ACCESS_TOKEN_NAME = "app-level"
 
     sanicjwt = Initialize(
@@ -58,7 +58,7 @@ def test_configuration_initialize_class_instance_level():
 
 
 def test_configuration_initialize_class_instance_level_custom_classes():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_ACCESS_TOKEN_NAME = "app-level"
 
     class MyConfig(Configuration):
@@ -75,7 +75,7 @@ def test_configuration_initialize_class_instance_level_custom_classes():
 
 
 def test_configuration_initialize_class_with_getter():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         def set_access_token_name(self):
@@ -90,7 +90,7 @@ def test_configuration_initialize_class_with_getter():
 
 
 def test_configuration_initialize_class_as_argument():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         def set_access_token_name(self):
@@ -104,7 +104,7 @@ def test_configuration_initialize_class_as_argument():
 
 
 def test_configuration_warning_non_callable(caplog):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         set_access_token_name = "return-level"
@@ -124,7 +124,7 @@ def test_configuration_warning_non_callable(caplog):
 
 
 def test_configuration_warning_non_valid_key(caplog):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     Initialize(app, foobar="baz", authenticate=lambda: True)
 
@@ -137,7 +137,7 @@ def test_configuration_warning_non_valid_key(caplog):
 
 
 def test_configuration_dynamic_config():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     auth_header_key = "x-authorization-header"
 
     class MyConfig(Configuration):
@@ -191,7 +191,7 @@ def test_configuration_dynamic_config():
 
 
 def test_deprecated_handler_payload_scopes():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_HANDLER_PAYLOAD_SCOPES = lambda *a, **kw: {}
 
     with pytest.raises(exceptions.InvalidConfiguration):
@@ -199,7 +199,7 @@ def test_deprecated_handler_payload_scopes():
 
 
 def test_deprecated_payload_handler():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_PAYLOAD_HANDLER = lambda *a, **kw: {}
 
     with pytest.raises(exceptions.InvalidConfiguration):
@@ -207,7 +207,7 @@ def test_deprecated_payload_handler():
 
 
 def test_deprecated_handler_payload_extend():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_HANDLER_PAYLOAD_EXTEND = lambda *a, **kw: {}
 
     with pytest.raises(exceptions.InvalidConfiguration):
@@ -215,7 +215,7 @@ def test_deprecated_handler_payload_extend():
 
 
 def test_empty_string_authorization_prefix():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     authorization_header = "custom-authorization-header"
     authorization_header_prefix = ""
 
@@ -262,7 +262,7 @@ def test_empty_string_authorization_prefix():
 
 
 def test_configuration_custom_class_and_config_item():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         access_token_name = ConfigItem("config-item-level")
@@ -275,7 +275,7 @@ def test_configuration_custom_class_and_config_item():
 
 
 def test_configuration_custom_class_and_config_item_as_method():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         def set_access_token_name(self):
@@ -289,7 +289,7 @@ def test_configuration_custom_class_and_config_item_as_method():
 
 
 def test_configuration_invalid_claim():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         claim_foo = "bar"
@@ -302,7 +302,7 @@ def test_configuration_invalid_claim():
 
 
 def test_disable_protection():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     async def authenticate(request, *args, **kwargs):
         return {"user_id": 1}
@@ -321,7 +321,7 @@ def test_disable_protection():
 
 
 def test_configuration_with_override():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(
         app, authenticate=lambda: True, access_token_name="customtoken"
@@ -336,7 +336,7 @@ def test_configuration_with_override():
 
 
 def test_configuration_with_override_on_aliased():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(app, authenticate=lambda: True,)
 

--- a/tests/test_custom_claims.py
+++ b/tests/test_custom_claims.py
@@ -89,28 +89,28 @@ def test_custom_claims_bad(authenticate):
         pass
 
     with pytest.raises(exceptions.InvalidCustomClaim):
-        sanic_app = Sanic()
+        sanic_app = Sanic("sanic-jwt-test")
         Initialize(
             sanic_app,
             authenticate=authenticate,
             custom_claims=[MissingVerifyClaim],
         )
     with pytest.raises(exceptions.InvalidCustomClaim):
-        sanic_app = Sanic()
+        sanic_app = Sanic("sanic-jwt-test")
         Initialize(
             sanic_app,
             authenticate=authenticate,
             custom_claims=[MissingSetupClaim],
         )
     with pytest.raises(exceptions.InvalidCustomClaim):
-        sanic_app = Sanic()
+        sanic_app = Sanic("sanic-jwt-test")
         Initialize(
             sanic_app,
             authenticate=authenticate,
             custom_claims=[MissingKeyClaim],
         )
     with pytest.raises(exceptions.InvalidCustomClaim):
-        sanic_app = Sanic()
+        sanic_app = Sanic("sanic-jwt-test")
         Initialize(
             sanic_app, authenticate=authenticate, custom_claims=[BogusClaim]
         )

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -19,7 +19,7 @@ def test_forgotten_initialized_on_protected():
     async def scoped_endpoint(request):
         return json({"scoped": True})
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(blueprint, app=app, authenticate=lambda x: True)
 
@@ -185,7 +185,7 @@ def test_inject_user_with_auth_mode_off(app_with_retrieve_user):
     async def retrieve_user(request, payload, *args, **kwargs):
         return {"user_id": 123}
 
-    microservice_app = Sanic()
+    microservice_app = Sanic("sanic-jwt-test")
     microservice_sanic_jwt = Initialize(
         microservice_app, auth_mode=False, retrieve_user=retrieve_user
     )
@@ -249,7 +249,7 @@ def test_redirect_with_decorator_url(app):
 
 
 def test_redirect_with_configured_url():
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app, auth_mode=False, login_redirect_url="/unprotected"
     )

--- a/tests/test_decorators_override_config.py
+++ b/tests/test_decorators_override_config.py
@@ -21,7 +21,7 @@ async def my_scope_extender(user, *args, **kwargs):
 def test_decorators_override_configuration_defaults():
     blueprint = Blueprint("Test")
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(
         blueprint,

--- a/tests/test_endpoints_async_methods.py
+++ b/tests/test_endpoints_async_methods.py
@@ -82,7 +82,7 @@ def app_with_async_methods():
 
     secret = str(binascii.hexlify(os.urandom(32)), "utf-8")
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         sanic_app,
         authenticate=authenticate,

--- a/tests/test_endpoints_auth.py
+++ b/tests/test_endpoints_auth.py
@@ -17,7 +17,7 @@ def payload(app, access_token):
     return jwt.decode(
         access_token,
         sanic_jwt.config.secret(),
-        algorithms=sanicjwt.config.algorithm(),
+        algorithms=sanic_jwt.config.algorithm(),
     )
 
 

--- a/tests/test_endpoints_blueprint.py
+++ b/tests/test_endpoints_blueprint.py
@@ -18,7 +18,7 @@ async def authenticate(request, *args, **kwargs):
     return {"user_id": 1}
 
 
-app = Sanic()
+app = Sanic("sanic-jwt-test")
 
 app.blueprint(blueprint)
 

--- a/tests/test_endpoints_cbv.py
+++ b/tests/test_endpoints_cbv.py
@@ -41,7 +41,7 @@ async def authenticate(request, *args, **kwargs):
     return user
 
 
-sanic_app = Sanic()
+sanic_app = Sanic("sanic-jwt-test")
 sanic_jwt = Initialize(sanic_app, authenticate=authenticate)
 
 

--- a/tests/test_endpoints_cookies.py
+++ b/tests/test_endpoints_cookies.py
@@ -35,7 +35,7 @@ def app_with_refresh_token_and_cookie(users, authenticate):
 
     secret = str(binascii.hexlify(os.urandom(32)), "utf-8")
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         sanic_app,
         authenticate=authenticate,
@@ -392,7 +392,7 @@ class TestEndpointsCookies(object):
 )
 def test_config_with_cookie_domain(users, authenticate):
     domain = "cookie.yum"
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     Initialize(
         sanic_app,
         authenticate=authenticate,
@@ -412,7 +412,7 @@ def test_config_with_cookie_domain(users, authenticate):
 
 def test_config_with_cookie_path(users, authenticate):
     path = "/auth"
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     Initialize(
         sanic_app, authenticate=authenticate, cookie_set=True, cookie_path=path
     )

--- a/tests/test_endpoints_custom.py
+++ b/tests/test_endpoints_custom.py
@@ -47,7 +47,7 @@ custom_endpoints = [
 
 def test_custom_endpoints_as_args():
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         app,
         authentication_class=MyAuthentication,

--- a/tests/test_endpoints_dict_first.py
+++ b/tests/test_endpoints_dict_first.py
@@ -30,7 +30,7 @@ def app_with_dict_test():
 
         return user
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         sanic_app, authenticate=authenticate, retrieve_user=retrieve_user
     )

--- a/tests/test_endpoints_extra.py
+++ b/tests/test_endpoints_extra.py
@@ -15,7 +15,7 @@ class MagicLoginHandler(BaseEndpoint):
         return json(response)
 
 
-app = Sanic()
+app = Sanic("sanic-jwt-test")
 initialize(
     app,
     authenticate=lambda: True,

--- a/tests/test_endpoints_init_on_bp_and_app.py
+++ b/tests/test_endpoints_init_on_bp_and_app.py
@@ -22,7 +22,7 @@ async def authenticate2(request, *args, **kwargs):
     return {"user_id": 2}
 
 
-app = Sanic()
+app = Sanic("sanic-jwt-test")
 
 
 @app.get("/", strict_slashes=True)

--- a/tests/test_endpoints_init_on_bp_decorated.py
+++ b/tests/test_endpoints_init_on_bp_decorated.py
@@ -10,7 +10,7 @@ async def authenticate(request, *args, **kwargs):
 
 
 blueprint = Blueprint("Test")
-app = Sanic()
+app = Sanic("sanic-jwt-test")
 sanicjwt = Initialize(blueprint, app=app, authenticate=authenticate)
 
 

--- a/tests/test_endpoints_init_on_bp_multiple.py
+++ b/tests/test_endpoints_init_on_bp_multiple.py
@@ -25,7 +25,7 @@ async def authenticate(request, *args, **kwargs):
     return {"user_id": 1}
 
 
-app = Sanic()
+app = Sanic("sanic-jwt-test")
 
 
 sanicjwt1 = Initialize(blueprint1, app=app, authenticate=authenticate)

--- a/tests/test_endpoints_init_on_bp_single.py
+++ b/tests/test_endpoints_init_on_bp_single.py
@@ -2,10 +2,10 @@ from sanic import Sanic
 from sanic.blueprints import Blueprint
 from sanic.response import json
 
-from sanic_jwt import Initialize
-from sanic_jwt.decorators import protected, scoped
+from sanic_jwt import Authentication, Initialize, protected, scoped
 
 blueprint = Blueprint("Test")
+cache = {}
 
 
 @blueprint.get("/", strict_slashes=True)
@@ -26,14 +26,34 @@ async def scoped(request):
     return json({"scoped": True})
 
 
-async def authenticate(request, *args, **kwargs):
-    return {"user_id": 1}
+class MyAuthentication(Authentication):
+    async def authenticate(self, request, *args, **kwargs):
+        return {"user_id": 1}
+
+    async def store_refresh_token(
+        self, user_id, refresh_token, *args, **kwargs
+    ):
+        key = "refresh_token_{user_id}".format(user_id=user_id)
+        cache[key] = refresh_token
+
+    async def retrieve_refresh_token(self, user_id, *args, **kwargs):
+        key = "refresh_token_{user_id}".format(user_id=user_id)
+        token = cache.get(key, None)
+        return token
+
+    async def retrieve_user(self, request, payload, *args, **kwargs):
+        return {"user_id": 1}
 
 
-app = Sanic()
+app = Sanic("sanic-jwt-test")
 
 
-sanicjwt = Initialize(blueprint, app=app, authenticate=authenticate)
+sanicjwt = Initialize(
+    blueprint,
+    app=app,
+    authentication_class=MyAuthentication,
+    refresh_token_enabled=True,
+)
 
 app.blueprint(blueprint, url_prefix="/test")
 
@@ -68,3 +88,61 @@ def test_scoped_empty():
     assert response.status == 401
     assert response.json.get("exception") == "Unauthorized"
     assert "Authorization header not present." in response.json.get("reasons")
+
+
+def test_authentication_all_methods():
+
+    _, response = app.test_client.post(
+        "/test/auth", json={"username": "user1", "password": "abcxyz"}
+    )
+
+    assert response.status == 200
+    assert sanicjwt.config.access_token_name() in response.json
+    assert sanicjwt.config.refresh_token_name() in response.json
+
+    access_token = response.json.get(sanicjwt.config.access_token_name(), None)
+    refresh_token = response.json.get(
+        sanicjwt.config.refresh_token_name(), None
+    )
+
+    assert access_token is not None
+    assert refresh_token is not None
+
+    _, response = app.test_client.get(
+        "/test/", headers={"Authorization": "Bearer {}".format(access_token)},
+    )
+
+    assert response.status == 200
+    assert response.json.get("message") == "hello world"
+
+    _, response = app.test_client.get(
+        "/test/auth/verify",
+        headers={"Authorization": "Bearer {}".format(access_token)},
+    )
+
+    assert response.status == 200
+
+    _, response = app.test_client.get(
+        "/test/auth/me",
+        headers={"Authorization": "Bearer {}".format(access_token)},
+    )
+
+    assert response.status == 200
+    assert "me" in response.json
+
+    _, response = app.test_client.post(
+        "/test/auth/refresh",
+        headers={"Authorization": "Bearer {}".format(access_token)},
+        json={sanicjwt.config.refresh_token_name(): refresh_token},
+    )
+
+    new_access_token = response.json.get(
+        sanicjwt.config.access_token_name(), None
+    )
+
+    assert response.status == 200
+    assert new_access_token is not None
+    assert (
+        response.json.get(sanicjwt.config.refresh_token_name(), None) is None
+    )  # there is no new refresh token
+    assert sanicjwt.config.refresh_token_name() not in response.json

--- a/tests/test_endpoints_jwt_cryptography.py
+++ b/tests/test_endpoints_jwt_cryptography.py
@@ -35,7 +35,7 @@ async def authenticate(request, *args, **kwargs):
 
 
 def test_jwt_rsa_crypto_from_path_object(public_rsa_key, private_rsa_key):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(
         app,
@@ -70,7 +70,7 @@ def test_jwt_rsa_crypto_from_path_object(public_rsa_key, private_rsa_key):
 
 
 def test_jwt_rsapss_crypto_from_path_object(public_rsa_key, private_rsa_key):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(
         app,
@@ -105,7 +105,7 @@ def test_jwt_rsapss_crypto_from_path_object(public_rsa_key, private_rsa_key):
 
 
 def test_jwt_ec_crypto_from_path_object(public_ec_key, private_ec_key):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(
         app,
@@ -140,7 +140,7 @@ def test_jwt_ec_crypto_from_path_object(public_ec_key, private_ec_key):
 
 
 def test_jwt_rsa_crypto_from_fullpath_as_str(public_rsa_key, private_rsa_key):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         secret = str(public_rsa_key)
@@ -178,7 +178,7 @@ def test_jwt_rsa_crypto_from_fullpath_as_str(public_rsa_key, private_rsa_key):
 def test_jwt_rsapss_crypto_from_fullpath_as_str(
     public_rsa_key, private_rsa_key
 ):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         secret = str(public_rsa_key)
@@ -215,7 +215,7 @@ def test_jwt_rsapss_crypto_from_fullpath_as_str(
 
 
 def test_jwt_ec_crypto_from_fullpath_as_str(public_ec_key, private_ec_key):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class MyConfig(Configuration):
         secret = str(public_ec_key)
@@ -251,7 +251,7 @@ def test_jwt_ec_crypto_from_fullpath_as_str(public_ec_key, private_ec_key):
 
 
 def test_jwt_rsa_crypto_from_str(public_rsa_key, private_rsa_key):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(
         app,
@@ -286,7 +286,7 @@ def test_jwt_rsa_crypto_from_str(public_rsa_key, private_rsa_key):
 
 
 def test_jwt_rsapss_crypto_from_str(public_rsa_key, private_rsa_key):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(
         app,
@@ -321,7 +321,7 @@ def test_jwt_rsapss_crypto_from_str(public_rsa_key, private_rsa_key):
 
 
 def test_jwt_ec_crypto_from_str(public_ec_key, private_ec_key):
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     sanicjwt = Initialize(
         app,
@@ -356,7 +356,7 @@ def test_jwt_ec_crypto_from_str(public_ec_key, private_ec_key):
 
 
 def test_jwt_crypto_wrong_keys():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     Initialize(
         app,
@@ -379,7 +379,7 @@ def test_jwt_crypto_wrong_keys():
 
 
 def test_jwt_crypto_very_long_path():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     n = 16 * 1024
 
     Initialize(
@@ -405,7 +405,7 @@ def test_jwt_crypto_very_long_path():
 def test_jwt_crypto_missing_private_key(public_rsa_key):
     with pytest.raises(exceptions.RequiredKeysNotFound):
         Initialize(
-            Sanic(),
+            Sanic("sanic-jwt-test"),
             authenticate=lambda: True,
             secret=public_rsa_key,
             algorithm="RS256",
@@ -414,18 +414,24 @@ def test_jwt_crypto_missing_private_key(public_rsa_key):
 
 def test_jwt_crypto_invalid_secret():
     with pytest.raises(exceptions.InvalidConfiguration):
-        Initialize(Sanic(), authenticate=lambda: True, secret=None)
+        Initialize(
+            Sanic("sanic-jwt-test"), authenticate=lambda: True, secret=None
+        )
     with pytest.raises(exceptions.InvalidConfiguration):
-        Initialize(Sanic(), authenticate=lambda: True, public_key="")
+        Initialize(
+            Sanic("sanic-jwt-test"), authenticate=lambda: True, public_key=""
+        )
 
     with pytest.raises(exceptions.InvalidConfiguration):
-        Initialize(Sanic(), authenticate=lambda: True, secret="     ")
+        Initialize(
+            Sanic("sanic-jwt-test"), authenticate=lambda: True, secret="     "
+        )
 
 
 def test_jwt_crypto_invalid_public_key(public_rsa_key, private_rsa_key):
     with pytest.raises(exceptions.RequiredKeysNotFound):
         Initialize(
-            Sanic(),
+            Sanic("sanic-jwt-test"),
             authenticate=lambda: True,
             public_key=public_rsa_key / "foo",
             private_key=private_rsa_key,
@@ -436,7 +442,7 @@ def test_jwt_crypto_invalid_public_key(public_rsa_key, private_rsa_key):
 def test_jwt_crypto_invalid_private_key(public_rsa_key, private_rsa_key):
     with pytest.raises(exceptions.RequiredKeysNotFound):
         Initialize(
-            Sanic(),
+            Sanic("sanic-jwt-test"),
             authenticate=lambda: True,
             public_key=public_rsa_key,
             private_key=private_rsa_key / "bar",
@@ -447,7 +453,7 @@ def test_jwt_crypto_invalid_private_key(public_rsa_key, private_rsa_key):
 def test_jwt_crypto_invalid_both_keys(public_rsa_key, private_rsa_key):
     with pytest.raises(exceptions.RequiredKeysNotFound):
         Initialize(
-            Sanic(),
+            Sanic("sanic-jwt-test"),
             authenticate=lambda: True,
             secret=public_rsa_key / "foo",
             private_key=private_rsa_key / "bar",

--- a/tests/test_endpoints_query_string.py
+++ b/tests/test_endpoints_query_string.py
@@ -35,7 +35,7 @@ def app_with_refresh_token(users, authenticate):
 
     secret = str(binascii.hexlify(os.urandom(32)), "utf-8")
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         sanic_app,
         authenticate=authenticate,

--- a/tests/test_endpoints_scoped.py
+++ b/tests/test_endpoints_scoped.py
@@ -81,7 +81,7 @@ def my_destructure_scopes(scopes, *args, **kwargs):
 @pytest.yield_fixture
 def app_with_scopes_base():
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
 
     @sanic_app.route("/")
     async def test(request):

--- a/tests/test_endpoints_scoped_simple.py
+++ b/tests/test_endpoints_scoped_simple.py
@@ -4,7 +4,7 @@ from sanic.response import json
 from sanic_jwt import initialize
 from sanic_jwt.decorators import scoped
 
-app = Sanic()
+app = Sanic("sanic-jwt-test")
 initialize(app, authenticate=lambda: True)
 
 

--- a/tests/test_endpoints_sync_methods.py
+++ b/tests/test_endpoints_sync_methods.py
@@ -64,7 +64,7 @@ def app_with_sync_methods(users):
         else:
             return None
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         sanic_app,
         authenticate=authenticate,

--- a/tests/test_extend_payload.py
+++ b/tests/test_extend_payload.py
@@ -47,7 +47,7 @@ def test_extend_simple():
         payload.update({"foo": "bar"})
         return payload
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         app, authenticate=authenticate, extend_payload=my_extender
     )
@@ -74,7 +74,7 @@ def test_extend_with_username():
         payload.update({"username": username})
         return payload
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         app, authenticate=authenticate, extend_payload=my_extender
     )
@@ -102,7 +102,7 @@ def test_extend_with_username_as_subclass():
             payload.update({"username": username})
             return payload
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     sanicjwt = Initialize(
         app, authenticate=authenticate, authentication_class=MyAuthentication
     )
@@ -128,7 +128,7 @@ def test_extend_with_mising_claim():
         del payload["nbf"]
         return payload
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     Initialize(
         app,
         authenticate=authenticate,

--- a/tests/test_extra_verifications.py
+++ b/tests/test_extra_verifications.py
@@ -42,7 +42,7 @@ def test_extra_verification_non_boolean_return(authenticate):
 
     extra_verifications = [bad_return]
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app,
         debug=True,
@@ -76,7 +76,7 @@ def test_extra_verification_non_callable(authenticate):
 
     extra_verifications = [123]
 
-    sanic_app = Sanic()
+    sanic_app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(
         sanic_app,
         debug=True,

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -7,7 +7,7 @@ from sanic_jwt import exceptions, Initialize, initialize
 
 
 def test_store_refresh_token_and_retrieve_refresh_token_ommitted():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     # app.config.SANIC_JWT_REFRESH_TOKEN_ENABLED = True
 
     with pytest.raises(exceptions.RefreshTokenNotImplemented):
@@ -15,7 +15,7 @@ def test_store_refresh_token_and_retrieve_refresh_token_ommitted():
 
 
 def test_store_refresh_token_ommitted():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_REFRESH_TOKEN_ENABLED = True
 
     with pytest.raises(exceptions.RefreshTokenNotImplemented):
@@ -25,7 +25,7 @@ def test_store_refresh_token_ommitted():
 
 
 def test_retrieve_refresh_token_ommitted():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_REFRESH_TOKEN_ENABLED = True
 
     with pytest.raises(exceptions.RefreshTokenNotImplemented):
@@ -35,7 +35,7 @@ def test_retrieve_refresh_token_ommitted():
 
 
 def test_store_refresh_token_and_retrieve_refresh_token_defined():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     app.config.SANIC_JWT_REFRESH_TOKEN_ENABLED = True
 
     initialize(
@@ -49,7 +49,7 @@ def test_store_refresh_token_and_retrieve_refresh_token_defined():
 
 
 def test_invalid_classview():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class NotAView(object):
         pass
@@ -61,21 +61,21 @@ def test_invalid_classview():
 
 
 def test_initialize_class_missing_authenticate():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     with pytest.raises(exceptions.AuthenticateNotImplemented):
         Initialize(app)
 
 
 def test_initialize_class():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     Initialize(app, authenticate=lambda: True)
 
     assert True
 
 
 def test_initialize_class_on_blueprint_missing_app():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     bp = Blueprint("test")
     app.blueprint(bp)
 
@@ -84,7 +84,7 @@ def test_initialize_class_on_blueprint_missing_app():
 
 
 def test_initialize_class_on_blueprint():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     bp = Blueprint("test")
     app.blueprint(bp)
 
@@ -94,7 +94,7 @@ def test_initialize_class_on_blueprint():
 
 
 def test_initialize_class_on_non_app_or_bp():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     class NotAnAppOrBP(object):
         pass
@@ -106,7 +106,7 @@ def test_initialize_class_on_non_app_or_bp():
 
 
 def test_initialize_class_on_multiple_blueprints():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     bp1 = Blueprint("test1")
     app.blueprint(bp1)
     bp2 = Blueprint("test2")
@@ -122,7 +122,7 @@ def test_initialize_class_on_multiple_blueprints():
 
 
 def test_initialize_class_on_app_and_blueprint():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     bp = Blueprint("test")
     app.blueprint(bp)
 
@@ -136,7 +136,7 @@ def test_initialize_class_on_app_and_blueprint():
 
 
 def test_initialize_class_on_blueprint_with_url_prefix():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     bp = Blueprint("test", url_prefix="/test")
     app.blueprint(bp)
 
@@ -146,7 +146,7 @@ def test_initialize_class_on_blueprint_with_url_prefix():
 
 
 def test_initialize_class_on_blueprint_with_url_prefix_and_config():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     bp = Blueprint("test", url_prefix="/test")
     app.blueprint(bp)
 
@@ -163,7 +163,7 @@ def test_initialize_with_custom_endpoint_not_subclassed():
         async def get(self, request):
             return text("ok")
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     with pytest.raises(exceptions.InvalidClassViewsFormat):
         Initialize(
             app,
@@ -176,7 +176,7 @@ def test_invalid_configuration_object():
     class MyInvalidConfiguration:
         MY_CUSTOM_SETTING = "foo"
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     with pytest.raises(exceptions.InitializationFailure):
         Initialize(app, configuration_class=MyInvalidConfiguration)
 
@@ -186,7 +186,7 @@ def test_invalid_authentication_object():
         async def authenticate(*args, **kwargs):
             return True
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     with pytest.raises(exceptions.InitializationFailure):
         Initialize(app, authentication_class=MyInvalidAuthentication)
 
@@ -195,13 +195,13 @@ def test_invalid_response_object():
     class MyInvalidResponses:
         pass
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     with pytest.raises(exceptions.InitializationFailure):
         Initialize(app, responses_class=MyInvalidResponses)
 
 
 def test_initialize_compat():
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     initialize(app, lambda: True)
 
@@ -210,7 +210,7 @@ def test_initialize_compat():
 
 def test_invalid_initialization_object():
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
 
     with pytest.raises(exceptions.InitializationFailure):
         Initialize(object, app=app, authenticate=lambda: True)
@@ -218,7 +218,7 @@ def test_invalid_initialization_object():
 
 def test_initialize_app_and_bp():
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     bp = Blueprint("bp", url_prefix="/bpapi")
     Initialize(instance=bp, app=app, authenticate=lambda: True)
 

--- a/tests/test_microservices.py
+++ b/tests/test_microservices.py
@@ -11,7 +11,7 @@ async def authenticate(username_table):
 
 
 def test_microservice_simple():
-    microservice_app = Sanic()
+    microservice_app = Sanic("sanic-jwt-test")
     Initialize(microservice_app, auth_mode=False)
 
     _, response = microservice_app.test_client.post(
@@ -22,7 +22,7 @@ def test_microservice_simple():
 
 
 def test_microservice_interaction():
-    microservice_app = Sanic()
+    microservice_app = Sanic("sanic-jwt-test")
     microservice_sanic_jwt = Initialize(microservice_app, auth_mode=False)
 
     @microservice_app.route("/protected")
@@ -30,7 +30,7 @@ def test_microservice_interaction():
     async def protected_request(request):
         return json({"protected": True})
 
-    app = Sanic()
+    app = Sanic("sanic-jwt-test")
     sanic_jwt = Initialize(app, authenticate=authenticate)
 
     _, response = microservice_app.test_client.get("/protected")


### PR DESCRIPTION
Removes decorator on `RefreshEndpoint` and moves it to mapping in the `Initialize` mapping to be flexible to also work when initializing on blueprint. See #190 
