### PR TITLE
make sure tokens are always strings

### DIFF
--- a/sanic_jwt/authentication.py
+++ b/sanic_jwt/authentication.py
@@ -495,7 +495,7 @@ class Authentication(BaseAuthentication):
             )
 
         access_token = jwt.encode(payload, secret, algorithm=algorithm)
-        return access_token
+        return str(access_token)
 
     async def generate_refresh_token(self, request, user):
         """
@@ -509,7 +509,7 @@ class Authentication(BaseAuthentication):
             refresh_token=refresh_token,
             request=request,
         )
-        return refresh_token
+        return str(refresh_token)
 
     async def is_authenticated(self, request):
         """


### PR DESCRIPTION
to avoid `TypeError: reject_bytes is on and '' is bytes` when serializing to json

