### PR TITLE
Pin pyjwt to >=2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ for reqs in extras_require.values():
     extras_require["all"].extend(reqs)
 
 install_requires = [
-    "pyjwt>=2.1.0,<3.0.0",
+    "pyjwt>=2.4.0,<3.0.0",
 ]
 
 setup(


### PR DESCRIPTION
sanic-jwt 1.8 release allows previous versions of PyJWT that are reported as vulnerable GHSA-ffqj-6fqr-9h24.