### PR TITLE
Fix typo causing example to not work

### DIFF
--- a/docs/source/pages/endpoints.rst
+++ b/docs/source/pages/endpoints.rst
@@ -286,7 +286,7 @@ You can customize how Sanic JWT handles responses on an exception by subclassing
                 'message': f'You encountered an exception: {exception_message}'
             }, status=exception.status_code)
 
-    Initialize(app, response_class=MyResponses)
+    Initialize(app, responses_class=MyResponses)
 
 
 ------------


### PR DESCRIPTION
## Goal
Fix typo in docs [example](https://sanic-jwt.readthedocs.io/en/latest/pages/endpoints.html#exception-handling)