### PR TITLE
Use `Cookie.__init__` instead of settings keys as a dict [Fixes #254]

### DIFF
--- a/sanic_jwt/responses.py
+++ b/sanic_jwt/responses.py
@@ -1,28 +1,25 @@
+from typing import Any
+
 from sanic.response import json
+from sanic import HTTPResponse
 
 from .base import BaseDerivative
 
-COOKIE_OPTIONS = (
-    ("domain", "cookie_domain"),
-    ("expires", "cookie_expires"),
-    ("max-age", "cookie_max_age"),
-    ("samesite", "cookie_samesite"),
-    ("secure", "cookie_secure"),
-)
+def _set_cookie(response : HTTPResponse, key : str, value : str, config, force_httponly : bool = None):
+    def value_or(val, def_val):
+        return val if val is not None else def_val
 
-
-def _set_cookie(response, key, value, config, force_httponly=None):
-    response.cookies[key] = value
-    response.cookies[key]["httponly"] = (
-        config.cookie_httponly() if force_httponly is None else force_httponly
+    response.cookies.add_cookie(
+        key=key,
+        value=value,
+        httponly=config.cookie_httponly() if force_httponly is None else force_httponly,
+        path=config.cookie_path(),
+        domain=value_or(config.cookie_domain(), None),
+        expires=value_or(config.cookie_expires(), None),
+        max_age=value_or(config.cookie_max_age(), None),
+        samesite=value_or(config.cookie_samesite(), "Lax"),
+        secure=value_or(config.cookie_secure(), True)
     )
-    response.cookies[key]["path"] = config.cookie_path()
-
-    for item, option in COOKIE_OPTIONS:
-        value = getattr(config, option)()
-        if value:
-            response.cookies[key][item] = value
-
 
 class Responses(BaseDerivative):
     @staticmethod

--- a/sanic_jwt/responses.py
+++ b/sanic_jwt/responses.py
@@ -1,22 +1,21 @@
+from typing import Optional
+
 from sanic.response import json
 from sanic import HTTPResponse
 
 from .base import BaseDerivative
 
-def _set_cookie(response : HTTPResponse, key : str, value : str, config, force_httponly : bool = None):
-    def value_or(val, def_val):
-        return val if val is not None else def_val
-
+def _set_cookie(response : HTTPResponse, key : str, value : str, config, force_httponly : Optional[bool] = None):
     response.cookies.add_cookie(
         key=key,
         value=value,
         httponly=config.cookie_httponly() if force_httponly is None else force_httponly,
         path=config.cookie_path(),
-        domain=value_or(config.cookie_domain(), None),
-        expires=value_or(config.cookie_expires(), None),
-        max_age=value_or(config.cookie_max_age(), None),
-        samesite=value_or(config.cookie_samesite(), "Lax"),
-        secure=value_or(config.cookie_secure(), True)
+        domain=config.cookie_domain() or None, # cookie_domain() may be '' (empty string)
+        expires=config.cookie_expires() or None, # cookie_expires() may be `0`
+        max_age=config.cookie_max_age() or None,
+        samesite=config.cookie_samesite() or "Lax",
+        secure=is_secure if (is_secure := config.cookie_secure()) is not None else True
     )
 
 class Responses(BaseDerivative):

--- a/sanic_jwt/responses.py
+++ b/sanic_jwt/responses.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from sanic.response import json
 from sanic import HTTPResponse
 


### PR DESCRIPTION
## Goal
Fix issue #254

## New Features/Changes
The functionality should've remained the same, it just fixes the deprecation warning that was emitted.
I'm unsure how this affects the min. supported version of Sanic, perhaps that should be updated too.

## Open Questions and TODOs
- [ ] I think there might've been a bug with setting the `secure` key. The original code did a falsey check, but `False` is also a falsey value, so the code didn't set the `secure` key to `False`, but rather left it at whatever it was by default. I fixed this by doing an explicit `None` check. Now, the TODO here is to check if my assumption/fix is correct.
- [ ] Brief test - I tested the changes by logging into my site, and everything works as it used to, but this time with no deprecation warnings.
